### PR TITLE
[Build] Rework Makefile rules to ease addition of LOC package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,21 @@ jobs:
 
     - name: Makefile-help
       run: make help
+
     - name: Build-C-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make clean && BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ make all-c-tests
+
     - name: Test-C-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make run-c-tests
+
     - name: Build-Cpp-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make all-cpp-tests
+
     - name: Test-Cpp-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make run-cpp-tests
+
     - name: Build-CC-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make all-cc-tests
+
     - name: Test-CC-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make run-cc-tests

--- a/include/l3.h
+++ b/include/l3.h
@@ -13,6 +13,15 @@
 
 #include <stdint.h>
 
+#ifdef L3_LOC_ENABLED
+#include "loc.h"
+#endif  // L3_LOC_ENABLED
+
+/**
+ * Macro to identify unused function argument.
+ */
+#define L3_ARG_UNUSED (0)
+
 /**
  * Size of circular ring-buffer to track log entries.
  */
@@ -37,6 +46,17 @@
 int l3_init(const char *path);
 
 /**
+ * \brief Caller-macro to invoke L3 simple logging.
+ */
+#ifdef L3_LOC_ENABLED
+#define l3_log_simple(msg, arg1, arg2)                          \
+        l3__log_simple(__LOC__, (msg), (arg1), (arg2))
+#else   // L3_LOC_ENABLED
+#define l3_log_simple(msg, arg1, arg2)                          \
+        l3__log_simple(L3_ARG_UNUSED, (msg), (arg1), (arg2))
+#endif  //
+
+/**
  * \brief Log a literal string and two arguments.
  *
  * \param msg  A literal string to log. (Note: Do -NOT- pass regular char*
@@ -48,7 +68,13 @@ int l3_init(const char *path);
  * l3_init(). To see the log output, run the l3_dump.py utility passing in
  * the names of the log file and the executable.
  */
-void l3_log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2);
+#ifdef L3_LOC_ENABLED
+void l3__log_simple(loc_t loc, const char *msg,
+                    const uint64_t arg1, const uint64_t arg2);
+#else
+void l3__log_simple(const uint32_t loc, const char *msg,
+                    const uint64_t arg1, const uint64_t arg2);
+#endif  // L3_LOC_ENABLED
 
 /**
  * \brief Log a message in as fast a way as possible.

--- a/src/l3.c
+++ b/src/l3.c
@@ -23,12 +23,19 @@
 
 #include "l3.h"
 
+#ifdef L3_LOC_ENABLED
+#include "loc.h"
+#endif  // L3_LOC_ENABLED
+
 /**
  * L3 Log entry Structure definitions:
  */
 struct l3_entry
 {
     pid_t       tid;
+#ifdef L3_LOC_ENABLED
+    loc_t       loc;
+#endif  // L3_LOC_ENABLED
     const char *msg;
     uint64_t    arg1;
     uint64_t    arg2;
@@ -101,10 +108,13 @@ l3_mytid(void)
 
 // ****************************************************************************
 void
-l3_log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2)
+l3__log_simple(uint32_t loc, const char *msg, const uint64_t arg1, const uint64_t arg2)
 {
     int idx = __sync_fetch_and_add(&l3_log->idx, 1) % L3_MAX_SLOTS;
     l3_log->slots[idx].tid = l3_mytid();
+#ifdef L3_LOC_ENABLED
+    l3_log->slots[idx].loc = (loc_t) loc;
+#endif
     l3_log->slots[idx].msg = msg;
     l3_log->slots[idx].arg1 = arg1;
     l3_log->slots[idx].arg2 = arg2;

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# ##############################################################################
+# test.sh - Driver script to build-and-test L3 toolset.
+# This script issues the same kinds of commands that are executed in
+# .github/workflows/build.yml . So, yes, there is some duplication, but this
+# script is provided for developers to test the changes before invoking CI.
+# ##############################################################################
+
+Me=$(basename "$0")
+set -euo pipefail
+
+# Currently, this is a simplistic driver, just executing basic `make` commands
+# to ensure that all code / tools build correctly in release mode.
+
+set -x
+make clean && CC=gcc LD=g++ make all-c-tests
+make run-c-tests
+
+make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cpp-tests
+make run-cpp-tests
+
+make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cc-tests
+make run-cc-tests
+
+# Do it all test execution.
+make clean && CC=g++ CXX=g++ LD=g++ make all
+make run-tests


### PR DESCRIPTION
This commit refactors the Makefile rules to ease the addition of rules to integrate Line-of-Code (LOC) package in a follow-on commit. Several redundant TEST_*BIN* etc. symbols are purged.

Existing capabilities are unchanged, and we now additionally support:
```
$ make clean && CC=g++ CXX=g++ LD=g++ make all
$ make run-tests
```
... to build all .c, .cpp and .cc sample-programs and run them in one-pass.

Added `test.sh` wrapper script for devs to quickly re-run all the tests that are run in CI, for easily stabilizing changes w/o having to go thru CI.

----
### Updated `make help` usage messages (as a quick reference):

```
agurajada-Linux-Vm:[1559] $ make help

Usage:

To build all sample programs and run all unit-tests:
 make clean && CC=g++ CXX=g++ LD=g++ make all
 make run-tests

Alternatively, you may use multiple invocations in this sequence to build all sources:

To build C-sample programs and run unit-tests:
 make clean && CC=gcc LD=g++ make all-c-tests
 make run-c-tests

To build C++-sample .cpp programs and run unit-tests:
 make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cpp-tests
 make run-cpp-tests

To build C++-sample .cc programs and run unit-tests:
 make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cc-tests
 make run-cc-tests

Environment variables:
 BUILD_MODE={release,debug}
 BUILD_VERBOSE={0,1}
```

### NOTE: To the reviewer:

This is really a non-functional, code-cleanup, refactoring change.

I have folded-in the support for LOC package on top of this code in a test PR #8 , which shows that this refactoring greatly simplifies adding in `Makefile` rules to pick-up LOC's generated files and other Make-rules.

Additionally, in this change-set, you will see LOC making an appearance in `l3.h` and `l3.c` files:

I have edited the files to "prepare" the structures and L3 APIs to start working with 4-byte loc_t ID value.

Currently, all this is #ifdef'ed out under L3_LOC_ENABLED define.

In a future PR, the builds will be invoked with this -DL3_LOC_ENABLED which will - magically - activate this code, and L3 logging will become LOC-enabled.

Once this goes in, I am ready to submit a PR for integrating LOC with L3 package.