### PR TITLE
Invoke LOC's unpacking logic on L3 generated logs with L3_LOC_ENABLED=1 runs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,35 @@ jobs:
     - name: Test-CC-Samples
       run: BUILD_MODE=${{ matrix.build_type }} make run-cc-tests
 
+    # -------------------------------------------------------------------------
     - name: Build-and-Run-C-Samples-with-LOC
-      run: BUILD_MODE=${{ matrix.build_type }} make clean && BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ L3_LOC_ENABLED=1 make run-c-tests
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} make clean
+        BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ L3_LOC_ENABLED=1 make run-c-tests
 
+    # Just re-run the tests on data that was generated with LOC-enabled, but
+    # without the required env-var. This should exercise code in the Python
+    # dump script to skip decoding LOC-ID values.
+    # You need to execute this run tests target immediately after doing the
+    # build; otherwise, other test execution commands will `clean` stuff
+    # which will cause this run to need re-builds.
+    - name: Run-C-Samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ make run-c-tests
+
+    # -------------------------------------------------------------------------
     - name: Build-and-Run-Cpp-Samples-with-LOC
-      run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cpp-tests
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} make clean-l3
+        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cpp-tests
 
+    - name: Run-Cpp-Samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make run-cpp-tests
+
+    # -------------------------------------------------------------------------
     - name: Build-and-Run-CC-Samples-with-LOC
-      run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cc-tests
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} make clean-l3
+        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cc-tests
+
+    - name: Run-CC-Samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make run-cc-tests

--- a/Docs/build.md
+++ b/Docs/build.md
@@ -64,6 +64,71 @@ $ make run-cc-tests
 
 To see verbose build outputs use: `$ BUILD_VERBOSE=1 make ...`
 
+## Integration with the LOC package
+
+To integrate with the Line-of-Code (LOC) package, enable the `L3_LOC_ENABLED=1`
+environment variable.  Example `make` commands to build the library
+and to run the sample programs are shown below:
+
+```
+$ make clean
+
+$ L3_LOC_ENABLED=1 CC=gcc LD=g++ make all-c-tests
+
+$ L3_LOC_ENABLED=1 make run-c-tests
+```
+
+```
+$ make clean-l3
+
+$ L3_LOC_ENABLED=1 CC=g++ CXX=g++ LD=g++ make all-cpp-tests
+
+$ L3_LOC_ENABLED=1 make run-cpp-tests
+```
+
+```
+$ make clean-l3
+
+$ L3_LOC_ENABLED=1 CC=g++ CXX=g++ LD=g++ make all-cc-tests
+
+$ L3_LOC_ENABLED=1 make run-cc-tests
+
+```
+
+------
+
+The standalone `l3_dump.py` Python script, invoked under the `make` targets also
+recognizes the `L3_LOC_ENABLED=1` to unpack the encoded code-location ID to the
+file-name / line number.
+
+As an example, if you run this tool, by default, the LOC-ID value is reported by itself.
+See, e.g., `loc=65620` in the output below.
+
+```
+$ ./l3_dump.py /tmp/l3.cc-small-test.dat ./build/release/bin/test-use-cases/single-file-CC-program
+tid=10550 loc=65620 'Simple-log-msg-Args(1,2)' arg1=1 arg2=2
+tid=10550 loc=65621 'Potential memory overwrite (addr, size)' arg1=3735927486 arg2=1024
+tid=10550 loc=65622 'Invalid buffer handle (addr)' arg1=3203378125 arg2=0
+```
+
+To decode the code-location, run with the `L3_LOC_ENABLED=1` environment variable, as
+shown below. Under this environment-variable, the Python script requires a
+LOC-generated decoder binary named `<_program-name_>_loc`, to perform the decoding.
+
+In the example below, a decoder binary named
+`./build/release/bin/test-use-cases/single-file-CC-program_loc`
+is expected to be found in the `build/` area.
+
+See the decoded `single-file-CC-program/test-main.cc:84` in the output below:
+
+```
+$ L3_LOC_ENABLED=1 ./l3_dump.py /tmp/l3.cc-small-test.dat ./build/release/bin/test-use-cases/single-file-CC-program
+tid=10550 single-file-CC-program/test-main.cc:84  'Simple-log-msg-Args(1,2)' arg1=1 arg2=2
+tid=10550 single-file-CC-program/test-main.cc:85  'Potential memory overwrite (addr, size)' arg1=3735927486 arg2=1024
+tid=10550 single-file-CC-program/test-main.cc:86  'Invalid buffer handle (addr)' arg1=3203378125 arg2=0
+```
+
+
 ## CI-Support
 
 The [build.yml](../.github/workflows/build.yml) exercises these

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ root-cause race conditions. This is because `printf`() is relatively slow,
 and usually involves acquiring a lock, so it becomes a kind of
 synchronisation point.
 
-The Lightweight Logging Library (l3) has a fast but limited `printf` API:
+The Lightweight Logging Library ([l3](./include/l3.h)) has a fast but limited `printf` API:
 - `l3_log_simple()`: Takes about 10ns (Intel Core i7-1365U)
 - `l3_log_fast()`: An even faster, but more limited interface, which takes about 7ns.
 
@@ -14,7 +14,8 @@ Both routines are lockless implementations.
 
 ## Development Workflow
 
-Simply include `l3.h` and link against `l3.c` and `l3.S` (the latter is
+Simply include `l3.h` in your source file(s) where you wish to invoke the
+L3 logging interfaces. Then, link against `l3.c` and `l3.S` (the latter is
 an assembly file currently only available for x86-64 ). Then call
 `l3_init()` to configure the filename to which the logs will be written.
 
@@ -47,6 +48,41 @@ less storage space.)  The pointer should be to a string literal.
 The `l3_dump.py` utility will map the pointer to find the string
 literal to which it points from the executable, to generate a human-readable
 dump of the log.
+
+### Integration with the LOC package
+
+The L3 logging methods are integrated with the Line-of-Code (LOC) decoding
+package, which can be optionally enabled by the `L3_LOC_ENABLED=1` environment
+variable. This environment variable is recognized as part of the `make`
+build steps and also when executing the `l3_dump.py` script. The `LOC`
+package generates a few source files, automated by a Python script,
+[gen_loc_files.py](./LineOfCode/loc/gen_loc_files.py).
+
+**NOTE**: A few `Makefile` rules, defined under the `L3_LOC_ENABLED=1`
+check, are needed to incorporate these files into your build system.
+Check this project's [Makefile](./Makefile) to understand how-to apply
+these rules to your project where the L3 / LOC packages will be incorporated.
+
+When LOC is also enabled, the diagnostic data collected is unpacked to also
+report the file name and line number where the L3-log-line was emitted.
+
+A sample output looks like follows:
+
+```
+$ L3_LOC_ENABLED=1 ./l3_dump.py /tmp/l3.c-small-test.dat ./build/release/bin/test-use-cases/single-file-C-program
+
+tid=170657 single-file-C-program/test-main.c:85  'Simple-log-msg-Args(1,2)' arg1=1 arg2=2
+tid=170657 single-file-C-program/test-main.c:86  'Potential memory overwrite (addr, size)' arg1=3735927486 arg2=1024
+tid=170657 single-file-C-program/test-main.c:87  'Invalid buffer handle (addr)' arg1=3203378125 arg2=0
+```
+
+On each line, the `single-file-C-program/test-main.c:85` field indicates the
+code-location where the log-line was generated.
+
+The LOC-package generates this code-location information at compile-time, so
+there is very negligible performance overhead to track this additional data.
+
+------
 
 The technique is simple, but effective. And fast.
 

--- a/l3_dump.py
+++ b/l3_dump.py
@@ -8,18 +8,67 @@ Copyright (c) 2023-2024
 import sys
 import struct
 import subprocess
+import os
 
 if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} <logfile> <program-binary>")
+    print(" ")
+    print("Note: If L3 logging is done for <program-binary> with L3_LOC_ENABLED=1")
+    print("we expect to find the LOC-decoder binary named <program-binary>_loc")
     sys.exit(0)
 
+# #############################################################################
+# Check for required LOC-decoder binary, based on environment of run
+# If L3_LOC_ENABLED=1 is set in the env, search for a LOC-decoder binary
+# named "<program_binary>_loc".
+# #############################################################################
+PROGRAM_BIN = sys.argv[2]
+DECODE_LOC_ID = 0   # By default, we expect L3 logging was done w/LOC OFF.
+LOC_ENABLED = "L3_LOC_ENABLED"
+LOC_DECODER = "LOC_DECODER"
+if LOC_ENABLED in os.environ:
+    env_var_val = os.getenv(LOC_ENABLED)
+    if env_var_val == "1":
+        LOC_DECODER = PROGRAM_BIN + "_loc"
+        if os.path.exists(LOC_DECODER) is False:
+            print(f"Env-var {LOC_ENABLED}=1 is set, but required "
+                  + f"LOC-decoder binary {LOC_DECODER} is not found.")
+            sys.exit(1)
+
+        # LOC is in-use and LOC-decoder binary was found.
+        DECODE_LOC_ID = 1
+
+# #############################################################################
+def exec_binary(cmdargs:list):
+    """Execute a binary, with args, and print output to stdout."""
+    try:
+        with subprocess.Popen(cmdargs, stdout=subprocess.PIPE, text=True) as output:
+            sp_stdout, sp_stderr = output.communicate()
+
+    except subprocess.CalledProcessError as exc:
+        print(f"sp.run() Status: FAIL, rc={exc.returncode}"
+              + "\nstderrr={stderr} \nargs={exc.args}"
+              + "\nstdout={exc.stdout}"
+              + "\nstderr={exc.stderr}")
+
+    if sp_stderr is None:
+        return sp_stdout.strip('\n')
+    return sp_stdout + " " + sp_stderr
+
+# #############################################################################
+# main() begins here ...
+# #############################################################################
 # pylint: disable-next=line-too-long
-with subprocess.Popen(["readelf", "-x", ".rodata", sys.argv[2]], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) as section:
+with subprocess.Popen(["readelf", "-x", ".rodata", PROGRAM_BIN],
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.PIPE, text=True) as section:
     stdout, stderr = section.communicate()
     rodata_offs = int(stdout.split('\n')[2].split()[0], 0)
 
 # pylint: disable-next=line-too-long
-with subprocess.Popen(["readelf", "-p", ".rodata", sys.argv[2]], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) as p:
+with subprocess.Popen(["readelf", "-p", ".rodata", PROGRAM_BIN],
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.PIPE, text=True) as p:
     stdout, stderr = p.communicate()
 
 strings = {}
@@ -38,7 +87,11 @@ with open(sys.argv[1], 'rb') as file:
         row = file.read(32)
         tid, loc, ptr, arg1, arg2 = struct.unpack('<iiQQQ', row)
         offs = ptr - fibase - rodata_offs
+
         if loc == 0:
             print(f"{tid=} '{strings[offs]}' {arg1=} {arg2=}")
-        else:
+        elif DECODE_LOC_ID == 0:
             print(f"{tid=} {loc=} '{strings[offs]}' {arg1=} {arg2=}")
+        elif DECODE_LOC_ID == 1:
+            UNPACK_LOC = exec_binary([LOC_DECODER, '--brief', str(loc)])
+            print(f"{tid=} {UNPACK_LOC} '{strings[offs]}' {arg1=} {arg2=}")

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,30 @@
 Me=$(basename "$0")
 set -euo pipefail
 
+# #############################################################################
+# Exercise some error-check conditions
+# #############################################################################
+# Exercise the check in ./l3_dump.py which verifies that the LOC-decoder
+# binary exists for LOC-encoding output data. If not, it should fail with an
+# error message.
+# #############################################################################
+function test_l3_dump_py_missing_loc_decoder()
+{
+    set +e
+
+    local test_prog="./build/release/bin/test-use-cases/single-file-C-program_loc"
+    local tmp_prog="${test_prog}.bak"
+    mv "${test_prog}" "${tmp_prog}"
+
+    L3_LOC_ENABLED=1 ./l3_dump.py /tmp/l3.c-small-test.dat ${test_prog}
+
+    mv "${tmp_prog}" "${test_prog}"
+    set -e
+    echo " "
+    echo "${Me}: Expected failure in ./l3_dump.py execution. Continuiing ..."
+    echo " "
+}
+
 # Currently, this is a simplistic driver, just executing basic `make` commands
 # to ensure that all code / tools build correctly in release mode.
 
@@ -33,11 +57,13 @@ echo " "
 echo "${Me}: Run build-and-test for core L3 integration with LOC package and tests"
 echo " "
 set -x
-make clean    && CC=gcc LD=g++ L3_LOC_ENABLED=1 make all-c-tests
-make run-c-tests
+make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1 make all-c-tests
+L3_LOC_ENABLED=1 make run-c-tests
+
+test_l3_dump_py_missing_loc_decoder
 
 make clean-l3 && CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make all-cpp-tests
-make run-cpp-tests
+L3_LOC_ENABLED=1 make run-cpp-tests
 
 make clean-l3 && CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make all-cc-tests
-make run-cc-tests
+L3_LOC_ENABLED=1 make run-cc-tests


### PR DESCRIPTION
This commit leverages the LOC-generated LOC-decoder binary to unpack the loc_t LOC_ID value stashed away in L3 diag data files. This will be enabled under the `L3_LOC_ENABLED=1`env-var, which is need to integrate L3 with the LOC package
and to re-build the library and sample programs.

Functionally, `l3_dump.py` will trigger the LOC-decoder binary to unpack the LOC-ID, if found, and will report the file-name / line# pair where the l3-logging API was invoked. 

This scheme is supported uniformly for .c, .cpp and .cc files.

Sample output:
----
```
tid=170657 single-file-C-program/test-main.c:85  'Simple-log-msg-Args(1,2)' arg1=1 arg2=2
tid=170657 single-file-C-program/test-main.c:86  'Potential memory overwrite (addr, size)' arg1=3735927486 arg2=1024
tid=170657 single-file-C-program/test-main.c:87  'Invalid buffer handle (addr)' arg1=3203378125 arg2=0
```


Note the 'single-file-C-program/test-main.c:85' generated for each instance of the log-line.

Makefile:
  - Adjust Make dependencies to ensure that the output dir specified by the `--loc-decoder-dir` arg to the LOC generator is created before the generation step is run.

  - Run LOC generator with `--loc-decoder-dir` to relocate the generated binary in L3-specific build's bin/ dir.

l3_dump.py:
  - Support execution under `L3_LOC_ENABLED=1` env-var
  - Locate and execute the LOC-decoder binary `--brief` mode to map the stored LOC-ID value to (file:line#) pair.

test.sh: Add test execn for variations under L3_LOC_ENABLED=1

-----

#### NOTE to the reviewer

This commit (PR) delivers the first usable, externally visible functional milestone of the L3-LOC integration.

As we discussed, the new approach, LOC2, based on ELF-decoding, will be a future add-on. Let's try to clean this up and get it integrated, so that something workable can be made available to interested users.

The final version of updates resulting from doc.md files can be seen from [this dev-branch](https://github.com/undoio/l3/tree/gapisback/Unpack-LOC-ID).

As an example, here is some output from [this CI job](https://github.com/undoio/l3/actions/runs/8397176111/job/23000006199?pr=11):

---
```
$ python3 l3_dump.py /tmp/l3.cpp-small-test.dat ./build/release/bin/test-use-cases/single-file-Cpp-program
tid=3294 single-file-Cpp-program/test-main.cpp:84  'Simple-log-msg-Args(1,2)' arg1=1 arg2=2
tid=3294 single-file-Cpp-program/test-main.cpp:85  'Potential memory overwrite (addr, size)' arg1=3735927486 arg2=1024
tid=3294 single-file-Cpp-program/test-main.cpp:86  'Invalid buffer handle (addr)' arg1=3203378125 arg2=0
```

We can see in the output that the LOC-ID has been decoded to correctly report the .cpp file name and its line# where the `l3_log_simple()`interface was invoked.