### PR TITLE
Extend fast_log() assembly code to save-off LOC loc_t uint32_t value.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,8 @@ L3_CC_DATA          := $(TMPDIR)/$(L3PACKAGE).cc-$(TEST_DATA_SUFFIX)
 L3_CC_SMALL_DATA    := $(TMPDIR)/$(L3PACKAGE).cc-small-$(TEST_DATA_SUFFIX)
 
 # Name the data file created by unit-test program: l3.c-small-unit-test.dat
-L3_C_UNIT_TEST_DATA := $(TMPDIR)/$(L3PACKAGE).c-small-unit-$(TEST_DATA_SUFFIX)
+L3_C_UNIT_SLOW_LOG_TEST_DATA := $(TMPDIR)/$(L3PACKAGE).c-small-unit-$(TEST_DATA_SUFFIX)
+L3_C_UNIT_FAST_LOG_TEST_DATA := $(TMPDIR)/$(L3PACKAGE).c-fast-unit-$(TEST_DATA_SUFFIX)
 
 # ###################################################################
 # ---- Symbols to build test-code sample programs
@@ -435,6 +436,7 @@ endif
 ifdef L3_LOC_ENABLED
     CFLAGS += -DL3_LOC_ENABLED
     CFLAGS += -DLOC_FILE_INDEX=LOC_$(subst .,_,$(subst -,_,$(notdir $<)))
+    LDFLAGS += -DL3_LOC_ENABLED
 endif
 CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -Wfatal-errors -Werror
 
@@ -545,7 +547,9 @@ run-unit-tests: all-unit-tests
 	@echo '---- Run L3 unit-tests: ----'
 	./$(L3_C_UNIT_TEST_BIN)
 	@echo
-	python3 l3_dump.py $(L3_C_UNIT_TEST_DATA) ./$(L3_C_UNIT_TEST_BIN)
+	python3 l3_dump.py $(L3_C_UNIT_SLOW_LOG_TEST_DATA) ./$(L3_C_UNIT_TEST_BIN)
+	@echo
+	python3 l3_dump.py $(L3_C_UNIT_FAST_LOG_TEST_DATA) ./$(L3_C_UNIT_TEST_BIN)
 
 # ###################################################################
 #

--- a/include/l3.h
+++ b/include/l3.h
@@ -38,7 +38,7 @@
 
 /**
  * \brief Initialise the logging library.
- * 
+ *
  * \param path [opt] A filename to back the map where the log will be stored.
  *
  * \return 0 on success, or -1 on failure with \c errno set to something appropriate.
@@ -69,12 +69,21 @@ int l3_init(const char *path);
  * the names of the log file and the executable.
  */
 #ifdef L3_LOC_ENABLED
-void l3__log_simple(loc_t loc, const char *msg,
+void l3__log_simple(const loc_t loc, const char *msg,
                     const uint64_t arg1, const uint64_t arg2);
 #else
 void l3__log_simple(const uint32_t loc, const char *msg,
                     const uint64_t arg1, const uint64_t arg2);
 #endif  // L3_LOC_ENABLED
+
+/**
+ * \brief Caller-macro to invoke L3 Fast logging.
+ */
+#ifdef L3_LOC_ENABLED
+#define l3_log_fast(msg, arg1, arg2) l3__log_fast(__LOC__, (msg), (arg1), (arg2))
+#else   // L3_LOC_ENABLED
+#define l3_log_fast(msg, arg1, arg2) l3__log_fast(L3_ARG_UNUSED, (msg), (arg1), (arg2))
+#endif  //
 
 /**
  * \brief Log a message in as fast a way as possible.
@@ -84,4 +93,11 @@ void l3__log_simple(const uint32_t loc, const char *msg,
 #ifdef __cplusplus
 extern "C"
 #endif
-void l3_log_fast(const char *msg);
+
+#ifdef L3_LOC_ENABLED
+void l3__log_fast(const loc_t loc, const char *msg,
+                  const uint64_t arg1, const uint64_t arg2);
+#else
+void l3__log_fast(const uint32_t loc, const char *msg,
+                  const uint64_t arg1, const uint64_t arg2);
+#endif  // L3_LOC_ENABLED

--- a/l3.S
+++ b/l3.S
@@ -1,29 +1,34 @@
-.globl l3_log_fast // l3_log_fast(msg)
+.globl l3__log_fast // l3__log_fast(msg)
 .extern l3_log
-.extern mytid
 
-l3_log_fast:
-    mov %fs:0xfffffffffffffffc,%eax
-    test %rax,%rax
-    jnz .gotid
-    mov $186, %rax
-    syscall
-    mov %eax, %fs:0xfffffffffffffffc
+l3__log_fast:
+    mov %fs:0xfffffffffffffffc,%eax // Fetch the TLS-stashed TID into %eax
+    test %rax,%rax          // Did we already stash something?
+    jnz .gotid              //      Yes: avoid the syscall because doing so is slow.
+    mov $186, %rax          //      No: 1. do the syscall. First mov __NR_gettid into %rax (i.e. the syscall number)
+    push %rcx               //          2. preserve $rcx because the syscall can trash it.
+    syscall                 //          3. do the actual syscall
+    pop %rcx                //          4. restore $rcx which the syscall will have trashed.
+    mov %eax, %fs:0xfffffffffffffffc // 5. and stuff the tid in TLS so that we don't need to do the syscall next time.
 .gotid:
-    mov l3_log(%rip), %rcx      // l3_log -> rcx
-
-    mov  $1, %edx
-    lock xadd %rdx, (%rcx)
-    and $0x3fff, %edx           // idx -> rdx
-
-    add $32, %rcx
-    shl $5, %rdx
-    add %rdx, %rcx
-    mov %rax, (%rcx)  // tid
-    add $8, %rcx
-    mov %rdi, (%rcx)  // msg
-    add $8, %rcx
-    movq $0, (%rcx)  // arg1
-    add $8, %rcx
-    movq $0, (%rcx)  // arg1
+    mov l3_log(%rip), %r8   // fetch ptr to the global l3_log into register r8
+    mov  $1, %r9
+    lock xadd %r9, (%r8)    // atomically increment-and-fetch the index field in l3_log.
+    and $0x3fff, %r9        // idx %= L3_NUM_SLOTS
+    add $32, %r8            // point r8 at the beginning of the l3_log.slots array.
+    shl $5, %r9             // scale the index by sizeof(L3_ENTRY)
+    add %r9, %r8            // point r9 at our entry in the slots array.
+    mov %eax, (%r8)         // The tid is in %eax from the call to to gettid above.
+#ifdef L3_LOC_ENABLED
+    add $4, %r8             // Point r8 at the loc field of the slot.
+    mov %edi, (%r8)         // Stash the LOC value.
+    add $4, %r8             // Point r8 at the msg field of the slot.
+#else
+    add $8, %r8             // Point r8 at the msg field of the slot.
+#endif // L3_LOC_ENABLED
+    mov %rsi, (%r8)         // Stash the msg arg in the slot.
+    add $8, %r8             // Point r8 at the arg1 field in the slot.
+    movq %rdx, (%r8)        // Stash arg1 in the slot
+    add $8, %r8             // Point r8 at the arg2 field in the slot.
+    movq %rcx, (%r8)        // Stash arg2 in the slot.
     ret

--- a/src/l3.c
+++ b/src/l3.c
@@ -73,7 +73,7 @@ typedef struct l3_log
     L3_ENTRY slots[L3_MAX_SLOTS];
 } L3_LOG;
 
-L3_LOG *l3_log;
+L3_LOG *l3_log; // Also referenced in l3.S for fast-logging.
 
 // ****************************************************************************
 int
@@ -130,7 +130,7 @@ l3_mytid(void)
 
 // ****************************************************************************
 void
-l3__log_simple(uint32_t loc, const char *msg, const uint64_t arg1, const uint64_t arg2)
+l3__log_simple(const uint32_t loc, const char *msg, const uint64_t arg1, const uint64_t arg2)
 {
     int idx = __sync_fetch_and_add(&l3_log->idx, 1) % L3_MAX_SLOTS;
     l3_log->slots[idx].tid = l3_mytid();

--- a/tests/unit/l3_dump.py-test.c
+++ b/tests/unit/l3_dump.py-test.c
@@ -26,10 +26,23 @@
 
 #include "l3.h"
 
+// Function prototypes
+void test_l3_slow_log(void);
+void test_l3_fast_log(void);
+
 int
 main(const int argc, const char **argv)
 {
-    int e = l3_init("/tmp/l3.c-small-unit-test.dat");
+    test_l3_fast_log();
+    test_l3_slow_log();
+
+    return 0;
+}
+
+void test_l3_slow_log(void)
+{
+    const char *log = "/tmp/l3.c-small-unit-test.dat";
+    int e = l3_init(log);
     if (e) {
         abort();
     }
@@ -38,6 +51,21 @@ main(const int argc, const char **argv)
     l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
     l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
 
-    return 0;
+    printf("Generated slow log-entries to log-file: %s\n", log);
 }
 
+void test_l3_fast_log(void)
+{
+    const char *log = "/tmp/l3.c-fast-unit-test.dat";
+    int e = l3_init(log);
+    if (e) {
+        abort();
+    }
+    l3_log_fast("Fast-log-msg: Args(1,2)", 1, 2);
+    l3_log_fast("Fast-log-msg: Args(3,4)", 3, 4);
+    l3_log_fast("Fast-log-msg: Args(10,20)", 10, 20);
+    l3_log_fast("Fast-log-msg: Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
+    l3_log_fast("Fast-log-msg: Invalid buffer handle (addr)", 0xbeefabcd, 0);
+
+    printf("Generated fast log-entries to log-file: %s\n", log);
+}

--- a/use-cases/single-file-C-program/test-main.c
+++ b/use-cases/single-file-C-program/test-main.c
@@ -60,7 +60,7 @@ main(void)
     }
 
     for (n = 0; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("300-Mil Fast l3-log msgs");
+        l3_log_fast("300-Mil Fast l3-log msgs", n, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {

--- a/use-cases/single-file-CC-program/test-main.cc
+++ b/use-cases/single-file-CC-program/test-main.cc
@@ -64,8 +64,9 @@ main(void)
         abort();
     }
 
+    // Throw-in some variations to generate diff 'arg' values during logging.
     for (n = 0; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("300-Mil Fast l3-log msgs");
+        l3_log_fast("300-Mil Fast l3-log msgs", (n/L3_MILLION), n);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {

--- a/use-cases/single-file-Cpp-program/test-main.cpp
+++ b/use-cases/single-file-Cpp-program/test-main.cpp
@@ -65,7 +65,7 @@ main(void)
     }
 
     for (n = 0; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("300-Mil Fast l3-log msgs");
+        l3_log_fast("300-Mil Fast l3-log msgs", n, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {


### PR DESCRIPTION
This commit extends fast-logging interfaces, implemented by assembly code, to:

- Support recording 2 args as part of fast-logging.
- Record the code-location ID, LOC-ID, where l3_fast_log() is invoked.
      This is conditionally enabled if env-var L3_LOC_ENABLED=1 is set.

Add new unit-test case and adjust existing use-case sample-programs to exercise these new interfaces.

Co-authored by Greg Law, who reworked l3.S to support this integration.


-----

## Note to the reviewer

Greg -- I squashed your assembly changes developed separately with mine, and added one minor clean-up commit. I'll fold that in , before pushing.

Meanwhile, there is still one more nagging issue. See [this comment](https://github.com/undoio/l3/pull/16/files#r1555049023) of mine. No rush to review this right now; you can get to it once your schedule permits.