### PR TITLE
[25] Refactor test.sh into test-methods that are invoked by CI's build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,87 +24,100 @@ jobs:
         ls -aFlrt
         echo " "
 
-    - name: Makefile-help
-      run: make help
+    #! -------------------------------------------------------------------------
+    - name: test-test-sh-usages
+      run: |
+        ./test.sh --help
+        ./test.sh --list
 
-    - name: Build-and-Run-Unit-tests
-      run: BUILD_MODE=${{ matrix.build_type }} make clean && BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ make run-unit-tests
+    #! -------------------------------------------------------------------------
+    - name: test-code-formatting
+      run: |
+        ./test.sh test-pylint-check
+        shellcheck ./test.sh
 
-    - name: Build-C-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make clean && BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ make all-c-tests
+    #! -------------------------------------------------------------------------
+    - name: test-make-help
+      run: ./test.sh test-make-help
 
-    - name: Test-C-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make run-c-tests
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-unit-tests
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-unit-tests
 
-    - name: Build-Cpp-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make all-cpp-tests
+    - name: test-build-C-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-C-samples
 
-    - name: Test-Cpp-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make run-cpp-tests
+    - name: test-run-C-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-C-samples
 
-    - name: Build-CC-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make clean-l3 && BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make all-cc-tests
+    - name: test-build-Cpp-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-Cpp-samples
 
-    - name: Test-CC-Samples
-      run: BUILD_MODE=${{ matrix.build_type }} make run-cc-tests
+    - name: test-run-Cpp-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-Cpp-samples
+
+    - name: test-build-Cc-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-Cc-samples
+
+    - name: test-run-Cc-samples
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-Cc-samples
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-C-Samples-with-LOC
+    - name: test-build-and-run-C-samples-with-LOC
       run: |
-        BUILD_MODE=${{ matrix.build_type }} make clean
-        BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ L3_LOC_ENABLED=1 make run-c-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-C-samples-with-LOC
 
-    # Just re-run the tests on data that was generated with LOC-enabled, but
-    # without the required env-var. This should exercise code in the Python
-    # dump script to skip decoding LOC-ID values.
-    # You need to execute this run tests target immediately after doing the
-    # build; otherwise, other test execution commands will `clean` stuff
-    # which will cause this run to need re-builds.
-    - name: Run-C-Samples-with-LOC-wo-L3_LOC_ENABLED
-      run: BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ make run-c-tests
+    - name: test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED
+
+    # NOTE: This test should occur immediately after previous one.
+    - name: test-l3_dump_py-missing-loc_decoder
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-l3_dump_py-missing-loc_decoder
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-Cpp-Samples-with-LOC
+    - name: test-build-and-run-Cpp-samples-with-LOC
       run: |
-        BUILD_MODE=${{ matrix.build_type }} make clean-l3
-        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cpp-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cpp-samples-with-LOC
 
-    - name: Run-Cpp-Samples-with-LOC-wo-L3_LOC_ENABLED
-      run: BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make run-cpp-tests
+    - name: test-run-Cpp-samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-Cpp-samples-with-LOC-wo-L3_LOC_ENABLED
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-CC-Samples-with-LOC
+    - name: test-build-and-run-Cc-samples-with-LOC
       run: |
-        BUILD_MODE=${{ matrix.build_type }} make clean-l3
-        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cc-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cc-samples-with-LOC
 
-    - name: Run-CC-Samples-with-LOC-wo-L3_LOC_ENABLED
-      run: BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ make run-cc-tests
+    - name: test-run-Cc-samples-with-LOC-wo-L3_LOC_ENABLED
+      run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-run-Cc-samples-with-LOC-wo-L3_LOC_ENABLED
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-LOC-unit-test
+    - name: test-build-and-run-LOC-unit-test
       run: |
-        BUILD_MODE=${{ matrix.build_type }} make clean
-        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-loc-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-LOC-unit-test
 
     # -------------------------------------------------------------------------
     # For easier debugging: run following LOC-ELF build-and-test jobs with
     # verbose Make outputs: BUILD_VERBOSE=1
-    - name: Build-and-Run-C-Samples-with-LOC-ELF
+    - name: test-build-and-run-C-samples-with-LOC-ELF
       run: |
-        BUILD_MODE=${{ matrix.build_type }} make clean
-        BUILD_MODE=${{ matrix.build_type }} CC=gcc LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-c-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-C-samples-with-LOC-ELF
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-Cpp-Samples-with-LOC-ELF
+    - name: test-build-and-run-Cpp-samples-with-LOC-ELF
       run: |
         # Do 'clean' here rather than 'clean-l3', so we do full rebuilds
-        BUILD_MODE=${{ matrix.build_type }} make clean
-        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cpp-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cpp-samples-with-LOC-ELF
 
     # -------------------------------------------------------------------------
-    - name: Build-and-Run-CC-Samples-with-LOC-ELF
+    - name: test-build-and-run-Cc-samples-with-LOC-ELF
       run: |
         # Do 'clean' here rather than 'clean-l3', so we do full rebuilds
-        BUILD_MODE=${{ matrix.build_type }} make clean
-        BUILD_MODE=${{ matrix.build_type }} CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cc-tests
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cc-samples-with-LOC-ELF
+
+    # -------------------------------------------------------------------------
+    # Exercise the --from-test interface to verify that it still works to
+    # run thru last pair of code-formatting tests. (Minor duplication of
+    # these two low-impact tests.)
+    # -------------------------------------------------------------------------
+    - name: test-from-test-interface
+      run: ./test.sh --from-test test-pylint-check

--- a/Makefile
+++ b/Makefile
@@ -332,9 +332,6 @@ LOC_MACRO_TEST_CPP_PROGRAM_SRCS := $(wildcard $(LOC_MACRO_TEST_CPP_PROGRAM)/*.cp
 # Map the list of sources to resulting list-of-objects
 LOC_MACRO_TEST_CPP_PROGRAM_OBJS := $(LOC_MACRO_TEST_CPP_PROGRAM_SRCS:%.cpp=$(OBJDIR)/%.o)
 
-$(info $$LOC_MACRO_TEST_CPP_PROGRAM_SRCS = [ ${LOC_MACRO_TEST_CPP_PROGRAM_SRCS} ])
-$(info $$LOC_MACRO_TEST_CPP_PROGRAM_OBJS = [ ${LOC_MACRO_TEST_CPP_PROGRAM_OBJS} ])
-
 # Define a dependency of this sample program's binary to its list of objects
 LOC_MACRO_TEST_CPP_PROGRAM_BIN := $(BINDIR)/$(LOC_MACRO_TEST_CPP_PROGRAM)
 $(LOC_MACRO_TEST_CPP_PROGRAM_BIN): $(LOC_MACRO_TEST_CPP_PROGRAM_OBJS)
@@ -609,7 +606,6 @@ $(BINDIR)/%: | $$(@D)/.
 # run-tests: run-c-tests run-cpp-tests run-cc-tests run-unit-tests
 
 run-c-tests: all-c-tests
-	pylint l3_dump.py
 	@echo
 	@echo '---- Run C unit-tests: ----'
 	./$(C_UNIT_TEST_BIN)
@@ -655,16 +651,3 @@ run-loc-tests: all-loc-tests
 	@echo
 	@echo '---- Run LOC unit-test: ----'
 	./$(LOC_MACRO_TEST_BIN)
-
-# ###################################################################
-#
-test-old: use-cases/single-file-C-program/test-main.c src/l3.c l3.S include/l3.h
-	pylint l3_dump.py
-	g++ -I./include -Wall -o test -g -O3 -D_GNU_SOURCE use-cases/single-file-C-program/test-main.c src/l3.c l3.S
-	./test
-	@echo
-	./l3_dump.py
-	@echo
-	python3 l3_dump.py /tmp/l3_test ./test
-	@echo
-	python3 l3_dump.py /tmp/l3_small_test ./test

--- a/test.sh
+++ b/test.sh
@@ -1,37 +1,373 @@
 #!/bin/bash
 # ##############################################################################
 # test.sh - Driver script to build-and-test L3 toolset.
-# This script issues the same kinds of commands that are executed in
-# .github/workflows/build.yml . So, yes, there is some duplication, but this
-# script is provided for developers to test the changes before invoking CI.
+# This script provides "test" methods that are also invoked as part of CI
+# .github/workflows/build.yml . This way, if you run $ ./test.sh
+# you should get the same build-and-test coverage executed by CI jobs.
+#
+# History:
+# Modelled on a similar script from the Certifier Framework library:
+# See: https://github.com/ccc-certifier-framework/certifier-framework-for-confidential-computing/blob/main/CI/scripts/test.sh
 # ##############################################################################
 
 Me=$(basename "$0")
-set -euo pipefail
+set -Eeuo pipefail
+
+Build_mode="${BUILD_MODE:-release}"
+
+# 'Globals' to track which test function is / was executing ...
+This_fn=""
+
+# ###########################################################################
+# Set trap handlers for all errors. Needs -E (-o errtrace): Ensures that ERR
+# traps (see below) get inherited by functions, command substitutions, and
+# subshell environments
+# Ref: https://citizen428.net/blog/bash-error-handling-with-trap/
+# ###########################################################################
+function cleanup()
+{
+    set +x
+    echo " "
+    echo "${Me}: **** Error **** Failed command, ${BASH_COMMAND}, at line $(caller) while executing function ${This_fn}"
+}
+
+trap cleanup ERR
+
+# ##################################################################
+# Array of test function names. If you add a new test_<function>,
+# add it to this list, here, so that one can see it in --list output.
+# ##################################################################
+TestList=(
+           "test-build-and-run-unit-tests"
+
+           "test-build-C-samples"
+           "test-run-C-samples"
+
+           "test-build-Cpp-samples"
+           "test-run-Cpp-samples"
+
+           "test-build-Cc-samples"
+           "test-run-Cc-samples"
+
+           # These two should go back-to-back as a pair
+           "test-build-and-run-C-samples-with-LOC"
+           "test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED"
+
+           "test-l3_dump_py-missing-loc_decoder"
+
+           # These two should go back-to-back as a pair
+           "test-build-and-run-Cpp-samples-with-LOC"
+           "test-run-Cpp-samples-with-LOC-wo-L3_LOC_ENABLED"
+
+           # These two should go back-to-back as a pair
+           "test-build-and-run-Cc-samples-with-LOC"
+           "test-run-Cc-samples-with-LOC-wo-L3_LOC_ENABLED"
+
+           "test-build-and-run-LOC-unit-test"
+
+           "test-build-and-run-C-samples-with-LOC-ELF"
+           "test-build-and-run-Cpp-samples-with-LOC-ELF"
+           "test-build-and-run-Cc-samples-with-LOC-ELF"
+
+           # Keep these two at the end, so that we can exercise this
+           # script in CI with the --from-test interface, to run just
+           # these two tests.
+           "test-pylint-check"
+           "test-make-help"
+        )
 
 # #############################################################################
-# Exercise some error-check conditions
+# Print help / usage
+function usage()
+{
+   echo "Usage: $Me [--help | --list] [ --from-test <test-function-name> ] [test_all]"
+}
+
+# --------------------------------------------------------------------------
+# Driver function to list test functions available.
+function list_tests()
+{
+    echo "${Me}: List of builds and test cases to execute:"
+    list_items_for_array "${TestList[@]}"
+}
+
+function list_items_for_array()
+{
+    local items_array=("$@")
+    for str in "${items_array[@]}"; do
+        echo "  ${str}"
+    done
+}
+
 # #############################################################################
+# List the test-function in the same order here as listed in the TestList[].
+# (The 1st two are exceptions, left here for readability.)
+# #############################################################################
+function test-pylint-check()
+{
+    pylint ./l3_dump.py
+}
+
+# #############################################################################
+function test-make-help()
+{
+    make help
+}
+
+# #############################################################################
+function test-build-and-run-unit-tests()
+{
+    make clean
+    CC=gcc LD=g++ make run-unit-tests
+}
+
+# #############################################################################
+function test-build-C-samples()
+{
+    make clean
+    CC=gcc LD=g++ make all-c-tests
+}
+
+# #############################################################################
+function test-run-C-samples()
+{
+    make run-c-tests
+}
+
+# #############################################################################
+function test-build-Cpp-samples()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ make all-cpp-tests
+}
+
+# #############################################################################
+function test-run-Cpp-samples()
+{
+    make run-cpp-tests
+}
+
+# #############################################################################
+function test-build-Cc-samples()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ make all-cc-tests
+}
+
+# #############################################################################
+function test-run-Cc-samples()
+{
+    make run-cc-tests
+}
+
+# #############################################################################
+function test-build-and-run-C-samples-with-LOC()
+{
+    make clean
+    CC=gcc LD=g++ L3_LOC_ENABLED=1 make run-c-tests
+}
+
+# #############################################################################
+# Just re-run the tests on data that was generated with LOC-enabled, but
+# without the required env-var. This should exercise code in the Python
+# dump script to silently skip decoding LOC-ID values.
+# You need to execute this run tests target immediately after doing the
+# build; otherwise, other test execution commands will `clean` stuff
+# which will cause this run to need re-builds.
+# #############################################################################
+function test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED()
+{
+    CC=gcc LD=g++ make run-c-tests
+}
+
+# #############################################################################
+# Error-checking test-case: This should come immediately after
+# test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED(), so the required LOC-binary
+# is already present.
+#
 # Exercise the check in ./l3_dump.py which verifies that the LOC-decoder
 # binary exists for LOC-encoding output data. If not, it should fail with an
 # error message.
 # #############################################################################
-function test_l3_dump_py_missing_loc_decoder()
+function test-l3_dump_py-missing-loc_decoder()
 {
+    # Turn OFF, so test execution continues w/o failing immediately
     set +e
 
-    local test_prog="./build/release/bin/test-use-cases/single-file-C-program_loc"
-    local tmp_prog="${test_prog}.bak"
-    mv "${test_prog}" "${tmp_prog}"
+    # This binary should have been generated by previous test-case,
+    # test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED()
+    local test_prog="./build/${Build_mode}/bin/use-cases/single-file-C-program"
 
-    L3_LOC_ENABLED=1 ./l3_dump.py /tmp/l3.c-small-test.dat ${test_prog}
+    # Python dump script expects this LOC-decoder binary, with _loc suffix.
+    local loc_prog="${test_prog}_loc"
+    local tmp_prog="${loc_prog}.bak"
+    set -x
+    mv "${loc_prog}" "${tmp_prog}"
 
-    mv "${tmp_prog}" "${test_prog}"
+    L3_LOC_ENABLED=1 ./l3_dump.py /tmp/l3.c-small-test.dat "${test_prog}"
+
+    mv "${tmp_prog}" "${loc_prog}"
+    set +x
     set -e
     echo " "
     echo "${Me}: Expected failure in ./l3_dump.py execution. Continuiing ..."
     echo " "
 }
+
+# #############################################################################
+function test-build-and-run-Cpp-samples-with-LOC()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cpp-tests
+}
+
+# #############################################################################
+function test-run-Cpp-samples-with-LOC-wo-L3_LOC_ENABLED()
+{
+    CC=g++ CXX=g++ LD=g++ make run-cpp-tests
+}
+
+# #############################################################################
+function test-build-and-run-Cc-samples-with-LOC()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make run-cc-tests
+}
+
+# #############################################################################
+function test-run-Cc-samples-with-LOC-wo-L3_LOC_ENABLED()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ make run-cc-tests
+}
+
+# #############################################################################
+function test-build-and-run-LOC-unit-test()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-loc-tests
+}
+
+# #############################################################################
+# Run these builds with verbose output so we can see that the loc.c file is
+# being compiled with gcc even when CC is specified as g++ (or some other non-gcc)
+function test-build-and-run-C-samples-with-LOC-ELF()
+{
+    make clean
+    CC=gcc LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-c-tests
+}
+
+# #############################################################################
+function test-build-and-run-Cpp-samples-with-LOC-ELF()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cpp-tests
+}
+
+# #############################################################################
+function test-build-and-run-Cc-samples-with-LOC-ELF()
+{
+    make clean
+    CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cc-tests
+}
+
+# #############################################################################
+# Driver function to run a specific named test-method.
+# #############################################################################
+function run_test()
+{
+    test_fnname=$1
+    echo " "
+    echo "-------------------------------------------------------------------------"
+    echo "${Me}: $(TZ="America/Los_Angeles" date) Executing ${test_fnname} ..."
+    echo " "
+    set -x
+    ${test_fnname}
+    set +x
+}
+
+# #############################################################################
+# Run through the list of test-cases in TestList[] and execute each one.
+# #############################################################################
+function test_all()
+{
+    from_test=$1
+    msg="L3 build-and-test execution"
+    if [ "${from_test}" = "" ]; then
+        exec_msg="Start ${msg}"
+    else
+        exec_msg="Resume ${msg} from ${from_test}"
+    fi
+
+    echo "${Me}: $(TZ="America/Los_Angeles" date) ${exec_msg} ..."
+    echo " "
+
+    start_seconds=$SECONDS
+    for str in "${TestList[@]}"; do
+
+        # Skip tests if we are resuming test execution using --from-test
+        if [ "${from_test}" != "" ] && [ "${from_test}" != "${str}" ]; then
+            continue
+        fi
+        This_fn="${str}"
+        # shellcheck disable=SC2086
+        run_test $str
+
+        from_test=""    # Reset, so we can continue w/next test.
+    done
+
+   # Computed elapsed hours, mins, seconds from total elapsed seconds
+   total_seconds=$((SECONDS - start_seconds))
+   el_h=$((total_seconds / 3600))
+   el_m=$((total_seconds % 3600 / 60))
+   el_s=$((total_seconds % 60))
+
+   echo " "
+   echo "${Me}: $(TZ="America/Los_Angeles" date) Completed ${msg}: ${total_seconds} s [ ${el_h}h ${el_m}m ${el_s}s ]"
+
+}
+
+# ##################################################################
+# main() begins here
+# ##################################################################
+
+if [ $# -eq 1 ]; then
+    if [ "$1" == "--help" ]; then
+        usage
+        exit 0
+    elif [ "$1" == "--list" ]; then
+        list_tests
+        exit 0
+    fi
+fi
+
+# ------------------------------------------------------------------------
+# Fast-path execution support. You can invoke this script specifying the
+# name of one of the functions to execute a specific set of tests.
+# This way, one can debug script changes to ensure that test-execution
+# still works.
+# ------------------------------------------------------------------------
+if [ $# -ge 1 ]; then
+
+    if [ "$1" == "--from-test" ]; then
+        if [ $# -eq 1 ]; then
+            echo "${Me}: Error --from-test needs the name of a test-function to resume execution from."
+            exit 1
+        fi
+        # Resume test execution from named test-function
+        # shellcheck disable=SC2048,SC2086
+        test_all $2
+        exit 0
+    fi
+
+    This_fn=$1
+    # shellcheck disable=SC2048,SC2086
+    run_test $*
+    exit 0
+fi
+
+test_all ""
+exit 0
 
 # Currently, this is a simplistic driver, just executing basic `make` commands
 # to ensure that all code / tools build correctly in release mode.


### PR DESCRIPTION
This commit refactors `test.sh` into individual build-and-test test-methods, each of which can be invoked by name from CI's build.yml script.

All existing CI jobs are now reworked as test-methods in test.sh

```
Linux-Vm:[678] $ ./test.sh --help
Usage: test.sh [--help | --list] [ --from-test <test-function-name> ] [test_all]
```


### NOTE:

The basic change here is that `test.sh` now has this large collection of test-methods:

```
 40 TestList=(
 41            "test-build-and-run-unit-tests"
 42
 43            "test-build-C-samples"
 44            "test-run-C-samples"
 45
 46            "test-build-Cpp-samples"
 47            "test-run-Cpp-samples"
 48
 49            "test-build-Cc-samples"
 50            "test-run-Cc-samples"
 51
 52            # These two should go back-to-back as a pair
 53            "test-build-and-run-C-samples-with-LOC"
 54            "test-run-C-samples-with-LOC-wo-L3_LOC_ENABLED"
 55
 56            "test-l3_dump_py-missing-loc_decoder"
 57
 58            # These two should go back-to-back as a pair
 59            "test-build-and-run-Cpp-samples-with-LOC"
 60            "test-run-Cpp-samples-with-LOC-wo-L3_LOC_ENABLED"
 61
 62            # These two should go back-to-back as a pair
 63            "test-build-and-run-Cc-samples-with-LOC"
 64            "test-run-Cc-samples-with-LOC-wo-L3_LOC_ENABLED"
 65
 66            "test-build-and-run-LOC-unit-test"
 67
 68            "test-build-and-run-C-samples-with-LOC-ELF"
 69            "test-build-and-run-Cpp-samples-with-LOC-ELF"
 70            "test-build-and-run-Cc-samples-with-LOC-ELF"
 71
 72            # Keep these two at the end, so that we can exercise this
 73            # script in CI with the --from-test interface, to run just
 74            # these two tests.
 75            "test-pylint-check"
 76            "test-make-help"
 77         )
```

CI `build.yml` will invoke each test-method, as, e.g., `./test.sh test-build-Cpp-samples` and so on.

The inline make commands from build.yml are now packaged as test-methods in `test.sh`.

For example, the above-named test-method will be invoked from `build.yml` as:

```
 53     - name: test-build-Cpp-samples
 54       run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-Cpp-samples
 55
```