### PR TITLE
Refactor l3_dump.py, add pytests. Pre-stage Mac/OSX support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,14 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y pylint
+        sudo apt-get install -y pylint pip
+
+        pip install pytest
+
         set -x
         echo " "
         which pylint
+        which pytest
 
         echo " "
         ls -aFlrt
@@ -35,6 +39,10 @@ jobs:
       run: |
         ./test.sh test-pylint-check
         shellcheck ./test.sh
+
+    #! -------------------------------------------------------------------------
+    - name: test-pytests
+      run: ./test.sh test-pytests
 
     #! -------------------------------------------------------------------------
     - name: test-make-help

--- a/Docs/build.md
+++ b/Docs/build.md
@@ -1,12 +1,22 @@
 # L3 Logging Library - Build Instructions
 
-The L3 library is supported on Linux and has been tested on the
-Ubuntu 22.04.4 LTS (jammy) distro. Build steps are implemented via
-this [Makefile](../Makefile), tested and supported for the
-following versions of the compilers:
+The L3 library is supported on Linux and has been tested on
+the Ubuntu 22.04.4 LTS (jammy) Linux distro.
+Build steps are implemented via this [Makefile](../Makefile), tested and
+supported for the following versions of the compilers:
 
-- gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
-- g++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+- Linux:
+    - gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+    - g++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+
+## Prerequisites
+
+The [l3_dump.py](../l3_dump.py) Python script uses the `readelf` binary
+to decode L3 log-dump files. The `readelf` binary is usually part of the
+`binutils` package. Install this on your machine and update your `$PATH`
+to access `readelf`.
+
+## Quick-start
 
 The L3 package consists of core L3-source files and sample
 programs in the [test-use-cases/](../test-use-cases/) directory.
@@ -14,8 +24,6 @@ programs in the [test-use-cases/](../test-use-cases/) directory.
 `Makefile` rules implement building and running tests for the
 L3 package with a small collection of `.c`, and C++, `.cpp` or
 `.cc`, sample programs.
-
-## Quick-start
 
 Check `make` help / usage: `$ make help` and closely follow the
 commands specified.

--- a/l3_dump.py
+++ b/l3_dump.py
@@ -9,6 +9,9 @@ import sys
 import struct
 import subprocess
 import os
+import platform
+import shutil
+import re
 
 # ##############################################################################
 # Constants that tie the unpacking logic to L3's core structure's layout
@@ -16,33 +19,188 @@ import os
 L3_LOG_HEADER_SZ = 32  # bytes; offsetof(L3_LOG, slots)
 L3_ENTRY_SZ = 32       # bytes; sizeof(L3_ENTRY)
 
-if len(sys.argv) != 3:
-    print(f"Usage: {sys.argv[0]} <logfile> <program-binary>")
-    print(" ")
-    print("Note: If L3 logging is done for <program-binary> with L3_LOC_ENABLED=1")
-    print("we expect to find the LOC-decoder binary named <program-binary>_loc")
-    sys.exit(0)
-
 # #############################################################################
-# Check for required LOC-decoder binary, based on environment of run
-# If L3_LOC_ENABLED=1 is set in the env, search for a LOC-decoder binary
-# named "<program_binary>_loc".
 # #############################################################################
-PROGRAM_BIN = sys.argv[2]
+PROGRAM_BIN = 'unknown'
 DECODE_LOC_ID = 0   # By default, we expect L3 logging was done w/LOC OFF.
 LOC_ENABLED = "L3_LOC_ENABLED"
 LOC_DECODER = "LOC_DECODER"
-if LOC_ENABLED in os.environ:
-    env_var_val = os.getenv(LOC_ENABLED)
-    if env_var_val == "1":
-        LOC_DECODER = PROGRAM_BIN + "_loc"
-        if os.path.exists(LOC_DECODER) is False:
-            print(f"Env-var {LOC_ENABLED}=1 is set, but required "
-                  + f"LOC-decoder binary {LOC_DECODER} is not found.")
-            sys.exit(1)
 
-        # LOC is in-use and LOC-decoder binary was found.
-        DECODE_LOC_ID = 1
+# #############################################################################
+# Establish path / names to tools used here based on the OS-platform version
+# #############################################################################
+OS_UNAME_S = platform.system()
+
+if OS_UNAME_S == 'Linux':
+    READELF_BIN = 'readelf'
+    READELF_HEXDUMP_ARG = '-x'
+    READELF_STRDUMP_ARG = '-p'
+    READELF_STRING_SEP = ']  '
+    READELF_DATA_SECTION = '.rodata'
+
+# #############################################################################
+def check_usage():
+    """Simple usage check."""
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <logfile> <program-binary>")
+        print(" ")
+        print("Note: If L3 logging is done for <program-binary> with L3_LOC_ENABLED=1")
+        print("we expect to find the LOC-decoder binary named <program-binary>_loc")
+        sys.exit(0)
+
+# #############################################################################
+def set_decode_loc_id():
+    """
+    Check for required LOC-decoder binary, based on environment of run
+    If L3_LOC_ENABLED=1 is set in the env, search for a LOC-decoder binary
+    named "<program_binary>_loc".
+    """
+    program_bin = sys.argv[2]
+    decode_loc_id = DECODE_LOC_ID
+    loc_decoder = LOC_DECODER
+    if LOC_ENABLED in os.environ:
+        env_var_val = os.getenv(LOC_ENABLED)
+        if env_var_val == "1":
+            loc_decoder = program_bin + "_loc"
+            if os.path.exists(loc_decoder) is False:
+                print(f"Env-var {LOC_ENABLED}=1 is set, but required "
+                      + f"LOC-decoder binary {loc_decoder} is not found.")
+                sys.exit(1)
+
+            # LOC is in-use and LOC-decoder binary was found.
+            decode_loc_id = 1
+
+    return (program_bin, decode_loc_id, loc_decoder)
+
+# #############################################################################
+def which_binary(os_uname_s:str, bin_name:str):
+    """
+    Check to see if required binary is found in $PATH. Error out otherwise.
+    """
+    if shutil.which(bin_name) is None:
+        print(f"Required {os_uname_s} binary '{bin_name}' is not found in $PATH.")
+        sys.exit(1)
+
+# #############################################################################
+def parse_rodata_start_addr(program_bin:str) -> int:
+    """
+    Parse output from `readelf` to extract start address of section '.rodata'
+
+    We are parsing the following sample hexdump output on Linux:
+
+Hex dump of section '.rodata':
+  0x00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3.
+  ^^^^^^^^^^
+
+    Return int for 1st hex-value; i.e., 0x00002000 .
+    """
+    with subprocess.Popen([READELF_BIN, READELF_HEXDUMP_ARG,
+                           READELF_DATA_SECTION, program_bin],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, text=True) as section:
+        _stdout, _stderr = section.communicate()
+
+        _rodata_offs = parse_rodata_start_offset(_stdout)
+        return _rodata_offs
+
+# #############################################################################
+def parse_rodata_start_offset(input_str:str) -> int:
+    """
+    Parse output from `readelf` to extract start offset of .rodata section.
+    Returns: Start of `.rodata` section's hex-address as int.
+    """
+    _offset = -1
+
+    # --------------------------------------------------------------------------
+    # Compile a r.e. with named capture-group to extract the 1st hex-addr.
+    # We expect output to be: 0x00002000 01000200 ...
+    # Parse leading '0x' as optional, in case `readelf` on some platforms
+    # does not spit that out.
+    # --------------------------------------------------------------------------
+    hexdump_pat = re.compile(r'(\s*)(0x)?(?P<offset_hex>[0-9a-fA-F]+)(.*)')
+    for line in input_str.split('\n'):
+        # Skip any leader lines not matching required offset-string lines.
+        line_match = hexdump_pat.match(line)
+        if line_match is None:
+            continue
+
+        _offset = int(line_match.group('offset_hex'), 16)
+        break
+
+    return _offset
+
+
+# #############################################################################
+def parse_rodata_string_offsets(program_bin:str) -> dict:
+    """
+    Parse output from `readelf` to extract start offset of embedded strings.
+    The expected convention is that the strings are null-terminated in the
+    hexdump output.
+
+    We are parsing the following sample hexdump output on Linux:
+
+String dump of section '.rodata':
+  [     8]  /tmp/l3.c-small-unit-test.dat
+  [    26]  Simple-log-msg-Args(1,2)
+  [    3f]  Simple-log-msg-Args(3,4)
+
+    Build a dictionary from 'int-offset' -> string; i.e.
+        [ 8] : "/tmp/l3.c-small-unit-test.dat"
+        [38] : "Simple-log-msg-Args(1,2)"
+
+    ... and so on.
+    """
+    with subprocess.Popen([READELF_BIN, READELF_STRDUMP_ARG,
+                           READELF_DATA_SECTION,
+                           program_bin],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, text=True) as rodata_hexdump:
+        _stdout, _stderr = rodata_hexdump.communicate()
+
+    # pylint: disable-next=unused-variable
+    (_strings, nlines) = parse_string_offsets(_stdout)
+    return _strings
+
+# #############################################################################
+def parse_string_offsets(input_str:str) -> (dict,int):
+    """
+    Parse an input string that is stdout from `readelf`. Extract start offset
+    of embedded strings. Return a dictionary mapping {offset: string}.
+
+    The expected convention is that the strings are null-terminated in the
+    hexdump output. We only want to parse lines that list string offsets, like:
+
+  [     8]  /tmp/l3.c-small-unit-test.dat
+  [    26]  Simple-log-msg-Args(1,2)
+  [    3f]  Simple-log-msg-Args(3,4)
+
+    Returns: Dictionary mapping {offset: string} and # of valid-lines parsed.
+    """
+    _strings = {}
+
+    # --------------------------------------------------------------------------
+    # Compile a r.e. with named capture-groups to extract offset / msg fields.
+    # Allow for white-spaces in diff parts of the line around '[ ]' and in
+    # the front, and between phrases. This is designed to cope liberally with
+    # `readelf` output that may vary slightly on diff platforms; e.g. Mac/OSX.
+    # --------------------------------------------------------------------------
+    off_string_pat = re.compile(r'(\s*)\[\s*(?P<offset_hex>[0-9a-fA-F]+)(\s*)\](\s+)(?P<msg>.*)')
+    nlines = 0
+    for line in input_str.split('\n'):
+
+        # Skip any leader lines not matching required offset-string lines.
+        line_match = off_string_pat.match(line)
+        if line_match is None:
+            continue
+
+        nlines += 1
+        _offs = int(line_match.group('offset_hex'), 16)
+        str_start = line_match.group('msg')
+        # print(f"{_offs=}, {str_start=}")
+        _strings[_offs] = str_start
+
+    # Return # of valid-lines-parsed count, so pytests can verify it.
+    return (_strings, nlines)
 
 # #############################################################################
 def exec_binary(cmdargs:list):
@@ -61,76 +219,79 @@ def exec_binary(cmdargs:list):
         return sp_stdout.strip('\n')
     return sp_stdout + " " + sp_stderr
 
-# #############################################################################
-# main() begins here ...
-# #############################################################################
-# pylint: disable-next=line-too-long
-with subprocess.Popen(["readelf", "-x", ".rodata", PROGRAM_BIN],
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.PIPE, text=True) as section:
-    stdout, stderr = section.communicate()
-    rodata_offs = int(stdout.split('\n')[2].split()[0], 0)
+###############################################################################
+# main() driver
+###############################################################################
+# pylint: disable-msg=too-many-locals
+def main():
+    """
+    Shell to call do_main() with command-line arguments.
+    """
+    check_usage()
+    (program_bin, decode_loc_id, loc_decoder_bin) = set_decode_loc_id()
 
-# pylint: disable-next=line-too-long
-with subprocess.Popen(["readelf", "-p", ".rodata", PROGRAM_BIN],
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.PIPE, text=True) as p:
-    stdout, stderr = p.communicate()
+    # Validate that required binary used below are found in $PATH.
+    which_binary(OS_UNAME_S, READELF_BIN)
 
-strings = {}
-for line in stdout.split('\n')[2:]:
-    if line:
-        offs = int(line.split()[1][:-1], 16)
-        s = line.split("]  ")[1]
-        strings[offs] = s
+    rodata_offs = parse_rodata_start_addr(program_bin)
 
-with open(sys.argv[1], 'rb') as file:
-    # Unpack the 1st n-bytes as an L3_LOG{} struct to get a hold
-    # of the fbase-address stashed by the l3_init() call.
-    data = file.read(L3_LOG_HEADER_SZ)
-    idx, loc, fibase, _, _ = struct.unpack('<iiQQQ', data)
-    # print(f"{idx=} {fibase=:x}")
+    strings = parse_rodata_string_offsets(program_bin)
 
-    # pylint: disable=invalid-name
-    nentries = 0
-    loc_prev = 0
-    # Keep reading chunks of log-entries from file ...
-    while True:
-        row = file.read(L3_ENTRY_SZ)
-        len_row = len(row)
+    with open(sys.argv[1], 'rb') as file:
+        # Unpack the 1st n-bytes as an L3_LOG{} struct to get a hold
+        # of the fbase-address stashed by the l3_init() call.
+        data = file.read(L3_LOG_HEADER_SZ)
 
-        # Deal with eof
-        if not row or len_row == 0 or len_row < L3_ENTRY_SZ:
-            break
+        # pylint: disable-next=unused-variable
+        idx, loc, fibase, _, _ = struct.unpack('<iiQQQ', data)
+        # print(f"{idx=} {fibase=:x}")
 
-        tid, loc, ptr, arg1, arg2 = struct.unpack('<iiQQQ', row)
+        # pylint: disable=invalid-name
+        nentries = 0
+        loc_prev = 0
+        # Keep reading chunks of log-entries from file ...
+        while True:
+            row = file.read(L3_ENTRY_SZ)
+            len_row = len(row)
 
-        # If no entry was logged, ptr to message's string is expected to be NULL
-        if ptr == 0:
-            break
+            # Deal with eof
+            if not row or len_row == 0 or len_row < L3_ENTRY_SZ:
+                break
 
-        offs = ptr - fibase - rodata_offs
+            tid, loc, ptr, arg1, arg2 = struct.unpack('<iiQQQ', row)
 
-        # No location-ID will be recorded in log-files if L3_LOC_ENABLED is OFF.
-        if loc == 0:
-            print(f"{tid=} '{strings[offs]}' {arg1=} {arg2=}")
-        elif DECODE_LOC_ID == 0:
-            print(f"{tid=} {loc=} '{strings[offs]}' {arg1=} {arg2=}")
-        elif DECODE_LOC_ID == 1:
-            # ----------------------------------------------------------------
-            # Minor optimization to speed-up unpacking of L3 log-dumps from
-            # tests that log millions of log-entries from the same line-of-code.
-            # If we found a new location-ID, unpack it.
-            if loc != loc_prev:
-                UNPACK_LOC = exec_binary([LOC_DECODER, '--brief', str(loc)])
+            # If no entry was logged, ptr to message's string is expected to be NULL
+            if ptr == 0:
+                break
 
-                # Save-off location-ID and unpacked string for next loop
-                unpack_loc_prev = UNPACK_LOC
-                loc_prev = loc
-            else:
-                UNPACK_LOC = unpack_loc_prev
-            print(f"{tid=} {UNPACK_LOC} '{strings[offs]}' {arg1=} {arg2=}")
+            offs = ptr - fibase - rodata_offs
 
-        nentries += 1
+            # No location-ID will be recorded in log-files if L3_LOC_ENABLED is OFF.
+            if loc == 0:
+                print(f"{tid=} '{strings[offs]}' {arg1=} {arg2=}")
+            elif decode_loc_id == 0:
+                print(f"{tid=} {loc=} '{strings[offs]}' {arg1=} {arg2=}")
+            elif decode_loc_id == 1:
+                # ----------------------------------------------------------------
+                # Minor optimization to speed-up unpacking of L3 log-dumps from
+                # tests that log millions of log-entries from the same line-of-code.
+                # If we found a new location-ID, unpack it.
+                if loc != loc_prev:
+                    UNPACK_LOC = exec_binary([loc_decoder_bin, '--brief', str(loc)])
 
-print(f"Unpacked {nentries=} log-entries.")
+                    # Save-off location-ID and unpacked string for next loop
+                    unpack_loc_prev = UNPACK_LOC
+                    loc_prev = loc
+                else:
+                    UNPACK_LOC = unpack_loc_prev
+                print(f"{tid=} {UNPACK_LOC} '{strings[offs]}' {arg1=} {arg2=}")
+
+            nentries += 1
+
+    print(f"Unpacked {nentries=} log-entries.")
+
+###############################################################################
+# Start of the script: Execute only if run as a script
+###############################################################################
+if __name__ == "__main__":
+    main()

--- a/test.sh
+++ b/test.sh
@@ -69,6 +69,8 @@ TestList=(
            "test-build-and-run-Cpp-samples-with-LOC-ELF"
            "test-build-and-run-Cc-samples-with-LOC-ELF"
 
+           "test-pytests"
+
            # Keep these two at the end, so that we can exercise this
            # script in CI with the --from-test interface, to run just
            # these two tests.
@@ -106,6 +108,7 @@ function list_items_for_array()
 function test-pylint-check()
 {
     pylint ./l3_dump.py
+    pylint ./tests/pytests
 }
 
 # #############################################################################
@@ -269,6 +272,16 @@ function test-build-and-run-Cc-samples-with-LOC-ELF()
 {
     make clean
     CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cc-tests
+}
+
+# #############################################################################
+function test-pytests()
+{
+    pushd ./tests/pytests
+
+    pytest -v
+
+    popd
 }
 
 # #############################################################################

--- a/tests/pytests/l3_dump_parse_test.py
+++ b/tests/pytests/l3_dump_parse_test.py
@@ -1,0 +1,213 @@
+# #############################################################################
+# l3_dump_parse_test: Testing parsing methods in l3_dump.py
+#
+"""
+Basic unit-tests for methods in l3_dump.py. These tests exercise the core
+unpacking methods in this script using standalone data, to verify that core
+logic parsing `readelf` output works correctly.
+"""
+import os
+import sys
+
+# #############################################################################
+# Full dir-path where this tests/ dir lives
+L3PyTestsDir    = os.path.realpath(os.path.dirname(__file__))
+L3RootDir       = os.path.abspath(L3PyTestsDir + '/../..')
+
+sys.path.append(L3RootDir)
+
+# pylint: disable-msg=import-error,wrong-import-position
+import l3_dump
+
+# #############################################################################
+def test_parse_rodata_start_offset_basic():
+    """
+    Exercise basic parsing of parse_rodata_start_offset()
+    """
+    test_ro_data_hex_dump = """0x00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3."""
+    offset = l3_dump.parse_rodata_start_offset(test_ro_data_hex_dump)
+
+    exp_offset = int('0x00002000', 16)
+    assert offset == exp_offset
+
+# #############################################################################
+def test_parse_rodata_start_offset_leading_spaces():
+    """
+    Exercise basic parsing of parse_rodata_start_offset()
+    """
+    test_ro_data_hex_dump = """  0x00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3."""
+    offset = l3_dump.parse_rodata_start_offset(test_ro_data_hex_dump)
+
+    exp_offset = int('0x00002000', 16)
+    assert offset == exp_offset
+
+# #############################################################################
+def test_parse_rodata_start_offset_no_leading_hex_digits():
+    """
+    Exercise basic parsing of parse_rodata_start_offset() without leading '0x'
+    """
+    test_ro_data_hex_dump = """00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3."""
+    offset = l3_dump.parse_rodata_start_offset(test_ro_data_hex_dump)
+
+    exp_offset = int('0x00002000', 16)
+    assert offset == exp_offset
+
+# #############################################################################
+def test_parse_rodata_start_offset_with_spaces_and_no_leading_hex_digits():
+    """
+    Exercise basic parsing of parse_rodata_start_offset() without leading '0x'
+    """
+    test_ro_data_hex_dump = """  00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3."""
+    offset = l3_dump.parse_rodata_start_offset(test_ro_data_hex_dump)
+
+    exp_offset = int('0x00002000', 16)
+    assert offset == exp_offset
+
+# #############################################################################
+def test_parse_rodata_start_offset_readelf_dump():
+    """
+    Exercise basic parsing of parse_rodata_start_offset() using an input that
+    is exactly what Linux `readelf` spits out.
+    """
+    test_ro_data_hex_dump = """Hex dump of section '.rodata':
+  0x00002000 01000200 00000000 2f746d70 2f6c332e ......../tmp/l3.
+  """
+    offset = l3_dump.parse_rodata_start_offset(test_ro_data_hex_dump)
+
+    exp_offset = int('0x00002000', 16)
+    assert offset == exp_offset
+
+# #############################################################################
+def test_basic_parse_rodata_string_offsets():
+    """
+    Cross-check LOC-encoded value for few hard-coded inputs.
+    """
+    test_ro_data = """[   17d]  test string"""
+
+    (string_offs, nlines) = l3_dump.parse_string_offsets(test_ro_data)
+
+    assert nlines == 1
+
+    exp_hash = { 381: 'test string' }
+
+    pr_debug_info(test_ro_data, string_offs, exp_hash)
+
+    assert string_offs == exp_hash
+
+# #############################################################################
+def test_basic_parse_rodata_string_offsets_skip_junk_lines():
+    """
+    Cross-check LOC-encoded value for few hard-coded inputs. Inject some junk
+    leader / trailer lines, and verify that they are skipped.
+    """
+    test_ro_data = """String dump of section '.rodata':
+  [   17d]  test string
+  Unrelated junk-lines should be skipped
+  Blank line below should be skipped
+
+  [    73]  300-Mil Fast l3-log msgs
+  Trailer line should be skipped
+                    """
+
+    (string_offs, nlines) = l3_dump.parse_string_offsets(test_ro_data)
+
+    assert nlines == 2
+
+    exp_hash = { 115: '300-Mil Fast l3-log msgs', 381: 'test string' }
+
+    pr_debug_info(test_ro_data, string_offs, exp_hash)
+
+    assert string_offs == exp_hash
+
+# #############################################################################
+def test_basic_parse_rodata_string_offsets_with_varying_blanks():
+    """
+    Verify parsing r.e. that it correctly skips all variations in spaces.
+    The data is designed such that the offsets keep varying. Otherwise, the
+    parsing routine that builds-and-returns a hash, will eliminate duplicate
+    keys.
+    """
+    test_ro_data = """
+[100] test string
+ [101] test string
+[ 102] test string
+[103 ] test string
+ [104] test string
+ [ 105] test string
+ [ 106 ] test string
+[ 107 ]  test string
+  [   108  ]   test string
+"""
+
+    (string_offs, nlines) = l3_dump.parse_string_offsets(test_ro_data)
+
+    assert nlines == 9
+
+    exp_hash = {  256: 'test string'
+                , 257: 'test string'
+                , 258: 'test string'
+                , 259: 'test string'
+                , 260: 'test string'
+                , 261: 'test string'
+                , 262: 'test string'
+                , 263: 'test string'
+                , 264: 'test string'
+               }
+
+    pr_debug_info(test_ro_data, string_offs, exp_hash)
+
+    assert string_offs == exp_hash
+
+# #############################################################################
+def test_parse_rodata_string_offsets():
+    """
+    Cross-check LOC-encoded value for few hard-coded inputs.
+    This hard-coded .rodata output string is the one obtained from one of
+    the unit-tests.
+    """
+    test_ro_data = """String dump of section '.rodata':
+  [     8]  /tmp/l3.c-test.dat
+  [    21]  Exercise in-memory logging performance benchmarking: %d Mil simple/fast log msgs\n
+  [    73]  300-Mil Fast l3-log msgs
+  [    90]  %d Mil fast log msgs  : %luns/msg (avg)\n
+  [    b9]  300-Mil Simple l3-log msgs
+  [    d8]  %d Mil simple log msgs: %luns/msg (avg)\n
+  [   101]  /tmp/l3.c-small-test.dat
+  [   11a]  Simple-log-msg-Args(1,2)
+  [   138]  Potential memory overwrite (addr, size)
+  [   160]  Invalid buffer handle (addr)
+  [   17d]  test string"""
+
+    (string_offs, nlines) = l3_dump.parse_string_offsets(test_ro_data)
+
+    assert nlines == 11
+
+    exp_hash = {    8: '/tmp/l3.c-test.dat'
+                 , 33: 'Exercise in-memory logging performance benchmarking:'
+                        + ' %d Mil simple/fast log msgs'
+                , 115: '300-Mil Fast l3-log msgs'
+                , 144: '%d Mil fast log msgs  : %luns/msg (avg)'
+                , 185: '300-Mil Simple l3-log msgs'
+                , 216: '%d Mil simple log msgs: %luns/msg (avg)'
+                , 257: '/tmp/l3.c-small-test.dat'
+                , 282: 'Simple-log-msg-Args(1,2)'
+                , 312: 'Potential memory overwrite (addr, size)'
+                , 352: 'Invalid buffer handle (addr)'
+                , 381: 'test string'
+               }
+    assert string_offs == exp_hash
+
+# #############################################################################
+def pr_debug_info(ro_data:str, string_offs:dict, exp_hash:dict):
+    """
+    Debug routine: Print test ro_data string and the parsed string_offsets hash.
+    """
+    print(ro_data)
+
+    print("\nExpected string-offsets:\n")
+    for offset in exp_hash.keys():
+        print(f"{offset=} -> {exp_hash[offset]}")
+
+    print("\nActual string-offsets:\n")
+    for offset in string_offs.keys():
+        print(f"{offset=} -> {string_offs[offset]}")


### PR DESCRIPTION
This commit does wholesale refactoring and modularization of the code in `l3_dump.py` into small methods which are individually testable.

- Modularize existing code into parsing methods using regular expressions
      and captured-groups to extract individual fields from `.rodata` outputs.
      E.g., add parse_rodata_start_offset(), parse_string_offsets() which
      implement the parsing of the `readelf` output of .rodata section.

- Rework python script to lay-down flow into which support for Mac/OSX
      variant of `readelf` output(s) can be easily folded-in.

- Add tests/pytests/l3_dump_parse_test.py - Drive unit-testing of parsing
      logic thru new pytests.

- test.sh: Add test-pytests(), now also invoked thru CI build.yml

-------

## NOTE TO THE REVIEWER:


**Motivation**  Actually -- this entire change-set started because I tried to port this toolkit to Mac/OSX. On my Mac, I can't use Gnu binutils `readelf`, as the default installed `gcc` is actually `clang`.

I figured out that I needed to use LLVM-specific `/opt/local/libexec/llvm-13/bin/llvm-readelf`, which seems to have an output close-to but not quite the same as from Linux `readelf`.

Hence, all this parsing-logic rework to use regular-expressions. This rework will make it easier to port this toolkit to also run on Mac/OSX (without the fast-assembly support, of course).

-----

**Manual Testing** To test this out manually in your dev-branch clone of this repo, do: `$ ./test.sh test-pytests`

You will need to run these pre-install steps:

```
sudo apt-get install -y pylint pip
pip install pytest
```

I need to update the build.md to reflect these changes. I plan to do that when I extend support to mac/OSX, at which time some more docs will need to be updated, anyways.