### PR TITLE
[Test] Refactor use-cases sample programs into functions.

### DIFF
--- a/use-cases/single-file-C-program/test-main.c
+++ b/use-cases/single-file-C-program/test-main.c
@@ -1,7 +1,7 @@
 /**
  * *****************************************************************************
  * \file test.c -> test-main.c
- * \author Greg Law
+ * \author Greg Law, Aditya P. Gurajada
  * \brief L3: Lightweight Logging Library Unit-test
  * \version 0.1
  * \date 2023-12-24
@@ -22,6 +22,9 @@
 #define L3_MILLION      ((uint32_t) (1000 * 1000))
 #define L3_NS_IN_SEC    ((uint32_t) (1000 * 1000 * 1000))
 
+void test_perf_slow_logging(int nMil);
+void test_perf_fast_logging(int nMil);
+
 // Convert timespec value to nanoseconds units.
 static uint64_t inline
 timespec_to_ns(struct timespec *ts)
@@ -38,14 +41,9 @@ timespec_to_ns(struct timespec *ts)
 int
 main(void)
 {
+    // Logging perf benchmarking methods below share this log-file.
     int e = l3_init("/tmp/l3.c-test.dat");
     if (e) {
-        abort();
-    }
-
-    struct timespec ts0;
-    struct timespec ts1;
-    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
         abort();
     }
 
@@ -53,13 +51,58 @@ main(void)
     printf("\nExercise in-memory logging performance benchmarking: "
            "%d Mil simple/fast log msgs\n",
             nMil);
-    unsigned long n;
 
+    test_perf_fast_logging(nMil);
+    test_perf_slow_logging(nMil);
+
+    // Logging unit-tests share this log-file.
+    e = l3_init("/tmp/l3.c-small-test.dat");
+    if (e) {
+        abort();
+    }
+    l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
+    l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
+    l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
+    l3_log_fast("Fast-logging msg1", 10, 0xdeadbeef);
+    l3_log_fast("Fast-logging msg2", 20, 0xbeefbabe);
+
+    return 0;
+}
+
+void
+test_perf_slow_logging(int nMil)
+{
+    struct timespec ts0;
+    struct timespec ts1;
     if (clock_gettime(CLOCK_REALTIME, &ts0)) {
         abort();
     }
 
-    for (n = 0; n < (300 * L3_MILLION); n++) {
+    uint32_t n = 0;
+    for (n = 0; n < (nMil * L3_MILLION); n++) {
+        l3_log_simple("300-Mil Simple l3-log msgs", n, 0);
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
+        abort();
+    }
+    uint64_t nsec0 = timespec_to_ns(&ts0);
+    uint64_t nsec1 = timespec_to_ns(&ts1);
+
+    printf("%d Mil simple log msgs: %" PRIu64 "ns/msg (avg)\n",
+            nMil, (nsec1 - nsec0) / n);
+}
+
+void
+test_perf_fast_logging(int nMil)
+{
+    struct timespec ts0;
+    struct timespec ts1;
+    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
+        abort();
+    }
+    uint32_t n = 0;
+    for (n = 0; n < (nMil * L3_MILLION); n++) {
         l3_log_fast("300-Mil Fast l3-log msgs", n, 0);
     }
 
@@ -71,27 +114,4 @@ main(void)
 
     printf("%d Mil fast log msgs  : %" PRIu64 "ns/msg (avg)\n",
             nMil, (nsec1 - nsec0) / n);
-
-    for (n = 0; n < (nMil * L3_MILLION); n++) {
-        l3_log_simple("300-Mil Simple l3-log msgs", n, 0);
-    }
-
-    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
-        abort();
-    }
-    nsec0 = timespec_to_ns(&ts0);
-    nsec1 = timespec_to_ns(&ts1);
-
-    printf("%d Mil simple log msgs: %" PRIu64 "ns/msg (avg)\n",
-            nMil, (nsec1 - nsec0) / n);
-
-    e = l3_init("/tmp/l3.c-small-test.dat");
-    if (e) {
-        abort();
-    }
-    l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-    l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-    l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
-
-    return 0;
 }

--- a/use-cases/single-file-Cpp-program/test-main.cpp
+++ b/use-cases/single-file-Cpp-program/test-main.cpp
@@ -1,7 +1,7 @@
 /**
  * *****************************************************************************
  * \file test-main.cpp
- * \author Greg Law
+ * \author Aditya P. Gurajada, Greg Law
  * \brief L3: Lightweight Logging Library C++ Unit-test
  * \version 0.1
  * \date 2023-12-24
@@ -21,6 +21,9 @@ using namespace std;
 constexpr auto L3_MILLION      (1000 * 1000);
 constexpr auto L3_NS_IN_SEC    (1000 * 1000 * 1000);
 
+void test_perf_slow_logging(int nMil);
+void test_perf_fast_logging(int nMil);
+
 // Convert timespec value to nanoseconds units.
 static uint64_t inline
 timespec_to_ns(struct timespec *ts)
@@ -31,14 +34,9 @@ timespec_to_ns(struct timespec *ts)
 int
 main(void)
 {
+    // Logging perf benchmarking methods below share this log-file.
     auto e = l3_init("/tmp/l3.cpp-test.dat");
     if (e) {
-        abort();
-    }
-
-    struct timespec ts0;
-    struct timespec ts1;
-    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
         abort();
     }
 
@@ -46,8 +44,35 @@ main(void)
     printf("\nExercise in-memory logging performance benchmarking: "
            "%d Mil simple/fast log msgs\n",
             nMil);
-    auto n = L3_MILLION;
-    for (n = 0; n < (nMil * L3_MILLION); n++) {
+
+    test_perf_slow_logging(nMil);
+    test_perf_fast_logging(nMil);
+
+    // Logging unit-tests share this log-file.
+    e = l3_init("/tmp/l3.cpp-small-test.dat");
+    if (e) {
+        abort();
+    }
+    l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
+    l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
+    l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
+    l3_log_fast("Fast-logging msg1", 10, 0xdeadbeef);
+    l3_log_fast("Fast-logging msg2", 20, 0xbeefbabe);
+
+    return 0;
+}
+
+void
+test_perf_slow_logging(int nMil)
+{
+    struct timespec ts0;
+    struct timespec ts1;
+    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
+        abort();
+    }
+
+    auto n = 0;
+    for (; n < (nMil * L3_MILLION); n++) {
         l3_log_simple("300-Mil Simple l3-log msgs", 0, 0);
     }
 
@@ -59,31 +84,29 @@ main(void)
 
     cout << nMil << " Mil simple log msgs: " << ((nsec1 - nsec0) / n)
          << "ns/msg (avg)" << endl;
+}
 
+void
+test_perf_fast_logging(int nMil)
+{
+    struct timespec ts0;
+    struct timespec ts1;
     if (clock_gettime(CLOCK_REALTIME, &ts0)) {
         abort();
     }
 
-    for (n = 0; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("300-Mil Fast l3-log msgs", n, 0);
+    // Throw-in some variations to generate diff 'arg' values during logging.
+    auto n = 0;
+    for (; n < (300 * L3_MILLION); n++) {
+        l3_log_fast("300-Mil Fast l3-log msgs", (n/L3_MILLION), n);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {
         abort();
     }
-    nsec0 = timespec_to_ns(&ts0);
-    nsec1 = timespec_to_ns(&ts1);
+    auto nsec0 = timespec_to_ns(&ts0);
+    auto nsec1 = timespec_to_ns(&ts1);
 
-    cout << nMil << " Mil simple log msgs: " << ((nsec1 - nsec0) / n)
+    cout << nMil << " Mil fast log msgs: " << ((nsec1 - nsec0) / n)
          << "ns/msg (avg)" << endl;
-
-    e = l3_init("/tmp/l3.cpp-small-test.dat");
-    if (e) {
-        abort();
-    }
-    l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-    l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-    l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
-
-    return 0;
 }


### PR DESCRIPTION
This commit refactors inline code in main() of 3 use-cases sample programs into individual functions:

- test_perf_slow_logging() and test_perf_fast_logging()

No other logic has changed. This refactoring is done to enable writing pytests, in future, to verify the outputs of logging.