### PR TITLE
Develop client-server IPC msg Performance exerciser for L3-LOC overheads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,6 @@ jobs:
       run: ./test.sh test-make-help
 
     #! -------------------------------------------------------------------------
-    - name: test-build-client-server-perf-test
-      run: ./test.sh test-build-client-server-perf-test
-
-    #! -------------------------------------------------------------------------
     - name: test-build-and-run-unit-tests
       run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-unit-tests
 
@@ -165,6 +161,11 @@ jobs:
       run: |
         # Do 'clean' here rather than 'clean-l3', so we do full rebuilds
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cc-samples-with-LOC-ELF
+
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-client-server-perf-test
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test
 
     # -------------------------------------------------------------------------
     # Exercise the --from-test interface to verify that it still works to

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,10 @@ jobs:
       run: ./test.sh test-make-help
 
     #! -------------------------------------------------------------------------
+    - name: test-build-client-server-perf-test
+      run: ./test.sh test-build-client-server-perf-test
+
+    #! -------------------------------------------------------------------------
     - name: test-build-and-run-unit-tests
       run: BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-unit-tests
 

--- a/test.sh
+++ b/test.sh
@@ -72,6 +72,7 @@ TestList=(
            "test-build-and-run-C-samples-with-LOC-ELF"
            "test-build-and-run-Cpp-samples-with-LOC-ELF"
            "test-build-and-run-Cc-samples-with-LOC-ELF"
+           "test-build-client-server-perf-test"
 
            "test-pytests"
 
@@ -277,6 +278,13 @@ function test-build-and-run-Cc-samples-with-LOC-ELF()
 {
     make clean
     CC=g++ CXX=g++ LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make run-cc-tests
+}
+
+# #############################################################################
+function test-build-client-server-perf-test()
+{
+    make clean
+    make clean && CXX=g++ LD=g++ make client-server-perf-test
 }
 
 # #############################################################################

--- a/use-cases/client-server-msgs-perf/ename.c.inc
+++ b/use-cases/client-server-msgs-perf/ename.c.inc
@@ -1,0 +1,47 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation, either version 3 or (at your option) any      *
+* later version. This program is distributed without any warranty.  See   *
+* the file COPYING.gpl-v3 for details.                                    *
+\*************************************************************************/
+
+// Generated file. cp'ed here from `make all` output of the full repo sources.
+
+static char *ename[] = {
+    /*   0 */ "",
+    /*   1 */ "EPERM", "ENOENT", "ESRCH", "EINTR", "EIO", "ENXIO",
+    /*   7 */ "E2BIG", "ENOEXEC", "EBADF", "ECHILD",
+    /*  11 */ "EAGAIN/EWOULDBLOCK", "ENOMEM", "EACCES", "EFAULT",
+    /*  15 */ "ENOTBLK", "EBUSY", "EEXIST", "EXDEV", "ENODEV",
+    /*  20 */ "ENOTDIR", "EISDIR", "EINVAL", "ENFILE", "EMFILE",
+    /*  25 */ "ENOTTY", "ETXTBSY", "EFBIG", "ENOSPC", "ESPIPE",
+    /*  30 */ "EROFS", "EMLINK", "EPIPE", "EDOM", "ERANGE",
+    /*  35 */ "EDEADLK/EDEADLOCK", "ENAMETOOLONG", "ENOLCK", "ENOSYS",
+    /*  39 */ "ENOTEMPTY", "ELOOP", "", "ENOMSG", "EIDRM", "ECHRNG",
+    /*  45 */ "EL2NSYNC", "EL3HLT", "EL3RST", "ELNRNG", "EUNATCH",
+    /*  50 */ "ENOCSI", "EL2HLT", "EBADE", "EBADR", "EXFULL", "ENOANO",
+    /*  56 */ "EBADRQC", "EBADSLT", "", "EBFONT", "ENOSTR", "ENODATA",
+    /*  62 */ "ETIME", "ENOSR", "ENONET", "ENOPKG", "EREMOTE",
+    /*  67 */ "ENOLINK", "EADV", "ESRMNT", "ECOMM", "EPROTO",
+    /*  72 */ "EMULTIHOP", "EDOTDOT", "EBADMSG", "EOVERFLOW",
+    /*  76 */ "ENOTUNIQ", "EBADFD", "EREMCHG", "ELIBACC", "ELIBBAD",
+    /*  81 */ "ELIBSCN", "ELIBMAX", "ELIBEXEC", "EILSEQ", "ERESTART",
+    /*  86 */ "ESTRPIPE", "EUSERS", "ENOTSOCK", "EDESTADDRREQ",
+    /*  90 */ "EMSGSIZE", "EPROTOTYPE", "ENOPROTOOPT",
+    /*  93 */ "EPROTONOSUPPORT", "ESOCKTNOSUPPORT",
+    /*  95 */ "EOPNOTSUPP/ENOTSUP", "EPFNOSUPPORT", "EAFNOSUPPORT",
+    /*  98 */ "EADDRINUSE", "EADDRNOTAVAIL", "ENETDOWN", "ENETUNREACH",
+    /* 102 */ "ENETRESET", "ECONNABORTED", "ECONNRESET", "ENOBUFS",
+    /* 106 */ "EISCONN", "ENOTCONN", "ESHUTDOWN", "ETOOMANYREFS",
+    /* 110 */ "ETIMEDOUT", "ECONNREFUSED", "EHOSTDOWN", "EHOSTUNREACH",
+    /* 114 */ "EALREADY", "EINPROGRESS", "ESTALE", "EUCLEAN",
+    /* 118 */ "ENOTNAM", "ENAVAIL", "EISNAM", "EREMOTEIO", "EDQUOT",
+    /* 123 */ "ENOMEDIUM", "EMEDIUMTYPE", "ECANCELED", "ENOKEY",
+    /* 127 */ "EKEYEXPIRED", "EKEYREVOKED", "EKEYREJECTED",
+    /* 130 */ "EOWNERDEAD", "ENOTRECOVERABLE", "ERFKILL", "EHWPOISON"
+};
+
+#define MAX_ENAME 133

--- a/use-cases/client-server-msgs-perf/error_functions.c
+++ b/use-cases/client-server-msgs-perf/error_functions.c
@@ -1,0 +1,206 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU Lesser General Public License as published   *
+* by the Free Software Foundation, either version 3 or (at your option)   *
+* any later version. This program is distributed without any warranty.    *
+* See the files COPYING.lgpl-v3 and COPYING.gpl-v3 for details.           *
+\*************************************************************************/
+
+/* Listing 3-3 */
+
+/* error_functions.c
+
+   Some standard error handling routines used by various programs.
+*/
+#include <stdarg.h>
+#include "error_functions.h"
+#include "tlpi_hdr.h"
+#include "ename.c.inc"          /* Defines ename and MAX_ENAME */
+
+NORETURN
+static void
+terminate(Boolean useExit3)
+{
+    char *s;
+
+    /* Dump core if EF_DUMPCORE environment variable is defined and
+       is a nonempty string; otherwise call exit(3) or _exit(2),
+       depending on the value of 'useExit3'. */
+
+    s = getenv("EF_DUMPCORE");
+
+    if (s != NULL && *s != '\0')
+        abort();
+    else if (useExit3)
+        exit(EXIT_FAILURE);
+    else
+        _exit(EXIT_FAILURE);
+}
+
+/* Diagnose 'errno' error by:
+
+      * outputting a string containing the error name (if available
+        in 'ename' array) corresponding to the value in 'err', along
+        with the corresponding error message from strerror(), and
+
+      * outputting the caller-supplied error message specified in
+        'format' and 'ap'. */
+
+static void
+outputError(Boolean useErr, int err, Boolean flushStdout,
+        const char *format, va_list ap)
+{
+#define BUF_SIZE 500
+    char buf[BUF_SIZE], userMsg[BUF_SIZE], errText[BUF_SIZE];
+
+    vsnprintf(userMsg, BUF_SIZE, format, ap);
+
+    if (useErr)
+        snprintf(errText, BUF_SIZE, " [%s %s]",
+                (err > 0 && err <= MAX_ENAME) ?
+                ename[err] : "?UNKNOWN?", strerror(err));
+    else
+        snprintf(errText, BUF_SIZE, ":");
+
+#if __GNUC__ >= 7
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+    snprintf(buf, BUF_SIZE, "ERROR%s %s\n", errText, userMsg);
+#if __GNUC__ >= 7
+#pragma GCC diagnostic pop
+#endif
+
+    if (flushStdout)
+        fflush(stdout);       /* Flush any pending stdout */
+    fputs(buf, stderr);
+    fflush(stderr);           /* In case stderr is not line-buffered */
+}
+
+/* Display error message including 'errno' diagnostic, and
+   return to caller */
+
+void
+errMsg(const char *format, ...)
+{
+    va_list argList;
+    int savedErrno;
+
+    savedErrno = errno;       /* In case we change it here */
+
+    va_start(argList, format);
+    outputError(TRUE, errno, TRUE, format, argList);
+    va_end(argList);
+
+    errno = savedErrno;
+}
+
+/* Display error message including 'errno' diagnostic, and
+   terminate the process */
+
+void
+errExit(const char *format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    outputError(TRUE, errno, TRUE, format, argList);
+    va_end(argList);
+
+    terminate(TRUE);
+}
+
+/* Display error message including 'errno' diagnostic, and
+   terminate the process by calling _exit().
+
+   The relationship between this function and errExit() is analogous
+   to that between _exit(2) and exit(3): unlike errExit(), this
+   function does not flush stdout and calls _exit(2) to terminate the
+   process (rather than exit(3), which would cause exit handlers to be
+   invoked).
+
+   These differences make this function especially useful in a library
+   function that creates a child process that must then terminate
+   because of an error: the child must terminate without flushing
+   stdio buffers that were partially filled by the caller and without
+   invoking exit handlers that were established by the caller. */
+
+void
+err_exit(const char *format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    outputError(TRUE, errno, FALSE, format, argList);
+    va_end(argList);
+
+    terminate(FALSE);
+}
+
+/* The following function does the same as errExit(), but expects
+   the error number in 'errnum' */
+
+void
+errExitEN(int errnum, const char *format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    outputError(TRUE, errnum, TRUE, format, argList);
+    va_end(argList);
+
+    terminate(TRUE);
+}
+
+/* Print an error message (without an 'errno' diagnostic) */
+
+void
+fatal(const char *format, ...)
+{
+    va_list argList;
+
+    va_start(argList, format);
+    outputError(FALSE, 0, TRUE, format, argList);
+    va_end(argList);
+
+    terminate(TRUE);
+}
+
+/* Print a command usage error message and terminate the process */
+
+void
+usageErr(const char *format, ...)
+{
+    va_list argList;
+
+    fflush(stdout);           /* Flush any pending stdout */
+
+    fprintf(stderr, "Usage: ");
+    va_start(argList, format);
+    vfprintf(stderr, format, argList);
+    va_end(argList);
+
+    fflush(stderr);           /* In case stderr is not line-buffered */
+    exit(EXIT_FAILURE);
+}
+
+/* Diagnose an error in command-line arguments and
+   terminate the process */
+
+void
+cmdLineErr(const char *format, ...)
+{
+    va_list argList;
+
+    fflush(stdout);           /* Flush any pending stdout */
+
+    fprintf(stderr, "Command-line usage error: ");
+    va_start(argList, format);
+    vfprintf(stderr, format, argList);
+    va_end(argList);
+
+    fflush(stderr);           /* In case stderr is not line-buffered */
+    exit(EXIT_FAILURE);
+}

--- a/use-cases/client-server-msgs-perf/error_functions.c
+++ b/use-cases/client-server-msgs-perf/error_functions.c
@@ -27,16 +27,17 @@ terminate(Boolean useExit3)
 
     /* Dump core if EF_DUMPCORE environment variable is defined and
        is a nonempty string; otherwise call exit(3) or _exit(2),
-       depending on the value of 'useExit3'. */
-
+       depending on the value of 'useExit3'.
+    */
     s = getenv("EF_DUMPCORE");
 
-    if (s != NULL && *s != '\0')
+    if (s != NULL && *s != '\0') {
         abort();
-    else if (useExit3)
+    } else if (useExit3) {
         exit(EXIT_FAILURE);
-    else
+    } else {
         _exit(EXIT_FAILURE);
+    }
 }
 
 /* Diagnose 'errno' error by:
@@ -46,8 +47,8 @@ terminate(Boolean useExit3)
         with the corresponding error message from strerror(), and
 
       * outputting the caller-supplied error message specified in
-        'format' and 'ap'. */
-
+        'format' and 'ap'.
+*/
 static void
 outputError(Boolean useErr, int err, Boolean flushStdout,
         const char *format, va_list ap)
@@ -57,12 +58,13 @@ outputError(Boolean useErr, int err, Boolean flushStdout,
 
     vsnprintf(userMsg, BUF_SIZE, format, ap);
 
-    if (useErr)
+    if (useErr) {
         snprintf(errText, BUF_SIZE, " [%s %s]",
                 (err > 0 && err <= MAX_ENAME) ?
                 ename[err] : "?UNKNOWN?", strerror(err));
-    else
+    } else {
         snprintf(errText, BUF_SIZE, ":");
+    }
 
 #if __GNUC__ >= 7
 #pragma GCC diagnostic push
@@ -73,15 +75,16 @@ outputError(Boolean useErr, int err, Boolean flushStdout,
 #pragma GCC diagnostic pop
 #endif
 
-    if (flushStdout)
+    if (flushStdout) {
         fflush(stdout);       /* Flush any pending stdout */
+    }
     fputs(buf, stderr);
     fflush(stderr);           /* In case stderr is not line-buffered */
 }
 
 /* Display error message including 'errno' diagnostic, and
-   return to caller */
-
+   return to caller
+*/
 void
 errMsg(const char *format, ...)
 {
@@ -98,8 +101,8 @@ errMsg(const char *format, ...)
 }
 
 /* Display error message including 'errno' diagnostic, and
-   terminate the process */
-
+   terminate the process
+*/
 void
 errExit(const char *format, ...)
 {
@@ -125,8 +128,8 @@ errExit(const char *format, ...)
    function that creates a child process that must then terminate
    because of an error: the child must terminate without flushing
    stdio buffers that were partially filled by the caller and without
-   invoking exit handlers that were established by the caller. */
-
+   invoking exit handlers that were established by the caller.
+*/
 void
 err_exit(const char *format, ...)
 {
@@ -140,8 +143,8 @@ err_exit(const char *format, ...)
 }
 
 /* The following function does the same as errExit(), but expects
-   the error number in 'errnum' */
-
+   the error number in 'errnum'
+*/
 void
 errExitEN(int errnum, const char *format, ...)
 {
@@ -186,9 +189,7 @@ usageErr(const char *format, ...)
     exit(EXIT_FAILURE);
 }
 
-/* Diagnose an error in command-line arguments and
-   terminate the process */
-
+/* Diagnose an error in command-line arguments and terminate the process */
 void
 cmdLineErr(const char *format, ...)
 {

--- a/use-cases/client-server-msgs-perf/error_functions.h
+++ b/use-cases/client-server-msgs-perf/error_functions.h
@@ -1,0 +1,45 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU Lesser General Public License as published   *
+* by the Free Software Foundation, either version 3 or (at your option)   *
+* any later version. This program is distributed without any warranty.    *
+* See the files COPYING.lgpl-v3 and COPYING.gpl-v3 for details.           *
+\*************************************************************************/
+
+/* error_functions.h
+
+   Header file for error_functions.c.
+*/
+#ifndef ERROR_FUNCTIONS_H
+#define ERROR_FUNCTIONS_H
+
+/* Error diagnostic routines */
+
+void errMsg(const char *format, ...);
+
+#ifdef __GNUC__
+
+    /* This macro stops 'gcc -Wall' complaining that "control reaches
+       end of non-void function" if we use the following functions to
+       terminate main() or some other non-void function. */
+
+#define NORETURN __attribute__ ((__noreturn__))
+#else
+#define NORETURN
+#endif
+
+void errExit(const char *format, ...) NORETURN ;
+
+void err_exit(const char *format, ...) NORETURN ;
+
+void errExitEN(int errnum, const char *format, ...) NORETURN ;
+
+void fatal(const char *format, ...) NORETURN ;
+
+void usageErr(const char *format, ...) NORETURN ;
+
+void cmdLineErr(const char *format, ...) NORETURN ;
+
+#endif

--- a/use-cases/client-server-msgs-perf/error_functions.h
+++ b/use-cases/client-server-msgs-perf/error_functions.h
@@ -23,7 +23,8 @@ void errMsg(const char *format, ...);
 
     /* This macro stops 'gcc -Wall' complaining that "control reaches
        end of non-void function" if we use the following functions to
-       terminate main() or some other non-void function. */
+       terminate main() or some other non-void function.
+    */
 
 #define NORETURN __attribute__ ((__noreturn__))
 #else

--- a/use-cases/client-server-msgs-perf/get_num.h
+++ b/use-cases/client-server-msgs-perf/get_num.h
@@ -1,0 +1,30 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU Lesser General Public License as published   *
+* by the Free Software Foundation, either version 3 or (at your option)   *
+* any later version. This program is distributed without any warranty.    *
+* See the files COPYING.lgpl-v3 and COPYING.gpl-v3 for details.           *
+\*************************************************************************/
+
+/* get_num.h
+
+   Header file for get_num.c.
+*/
+#ifndef GET_NUM_H
+#define GET_NUM_H
+
+#define GN_NONNEG       01      /* Value must be >= 0 */
+#define GN_GT_0         02      /* Value must be > 0 */
+
+                                /* By default, integers are decimal */
+#define GN_ANY_BASE   0100      /* Can use any base - like strtol(3) */
+#define GN_BASE_8     0200      /* Value is expressed in octal */
+#define GN_BASE_16    0400      /* Value is expressed in hexadecimal */
+
+long getLong(const char *arg, int flags, const char *name);
+
+int getInt(const char *arg, int flags, const char *name);
+
+#endif

--- a/use-cases/client-server-msgs-perf/svmsg_file.h
+++ b/use-cases/client-server-msgs-perf/svmsg_file.h
@@ -32,7 +32,8 @@ struct requestMsg {                     /* Requests (client to server) */
 
 /* REQ_MSG_SIZE computes size of 'mtext' part of 'requestMsg' structure.
    We use offsetof() to handle the possibility that there are padding
-   bytes between the 'clientId' and 'pathname' fields. */
+   bytes between the 'clientId' and 'pathname' fields.
+*/
 
 #define REQ_MSG_SIZE (offsetof(struct requestMsg, pathname) - \
                       offsetof(struct requestMsg, clientId) + PATH_MAX)

--- a/use-cases/client-server-msgs-perf/svmsg_file.h
+++ b/use-cases/client-server-msgs-perf/svmsg_file.h
@@ -1,0 +1,51 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation, either version 3 or (at your option) any      *
+* later version. This program is distributed without any warranty.  See   *
+* the file COPYING.gpl-v3 for details.                                    *
+\*************************************************************************/
+
+/* svmsg_file.h
+
+   Header file for svmsg_file_server.c and svmsg_file_client.c.
+*/
+#include <sys/types.h>
+#include <sys/msg.h>
+#include <sys/stat.h>
+#include <stddef.h>                     /* For definition of offsetof() */
+#include <limits.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include "tlpi_hdr.h"
+
+#define SERVER_KEY 0x1aaaaaa1           /* Key for server's message queue */
+
+struct requestMsg {                     /* Requests (client to server) */
+    long mtype;                         /* Unused */
+    int  clientId;                      /* ID of client's message queue */
+    char pathname[PATH_MAX];            /* File to be returned */
+};
+
+/* REQ_MSG_SIZE computes size of 'mtext' part of 'requestMsg' structure.
+   We use offsetof() to handle the possibility that there are padding
+   bytes between the 'clientId' and 'pathname' fields. */
+
+#define REQ_MSG_SIZE (offsetof(struct requestMsg, pathname) - \
+                      offsetof(struct requestMsg, clientId) + PATH_MAX)
+
+#define RESP_MSG_SIZE 8192
+
+struct responseMsg {                    /* Responses (server to client) */
+    long mtype;                         /* One of RESP_MT_* values below */
+    char data[RESP_MSG_SIZE];           /* File content / response message */
+};
+
+/* Types for response messages sent from server to client */
+
+#define RESP_MT_FAILURE 1               /* File couldn't be opened */
+#define RESP_MT_DATA    2               /* Message contains file data */
+#define RESP_MT_END     3               /* File data complete */

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -1,0 +1,95 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation, either version 3 or (at your option) any      *
+* later version. This program is distributed without any warranty.  See   *
+* the file COPYING.gpl-v3 for details.                                    *
+\*************************************************************************/
+
+/* svmsg_file_client.c
+
+   Send a message to the server svmsg_file_server.c requesting the
+   contents of the file named on the command line, and then receive the
+   file contents via a series of messages sent back by the server. Display
+   the total number of bytes and messages received. The server and client
+   communicate using System V message queues.
+*/
+#include "svmsg_file.h"
+
+static int clientId;
+
+static void
+removeQueue(void)
+{
+    if (msgctl(clientId, IPC_RMID, NULL) == -1)
+        errExit("msgctl");
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct requestMsg req;
+    struct responseMsg resp;
+    int serverId, numMsgs;
+    ssize_t msgLen, totBytes;
+
+    if (argc != 2 || strcmp(argv[1], "--help") == 0)
+        usageErr("%s pathname\n", argv[0]);
+
+    if (strlen(argv[1]) > sizeof(req.pathname) - 1)
+        cmdLineErr("pathname too long (max: %ld bytes)\n",
+                (long) sizeof(req.pathname) - 1);
+
+    /* Get server's queue identifier; create queue for response */
+
+    serverId = msgget(SERVER_KEY, S_IWUSR);
+    if (serverId == -1)
+        errExit("msgget - server message queue");
+
+    clientId = msgget(IPC_PRIVATE, S_IRUSR | S_IWUSR | S_IWGRP);
+    if (clientId == -1)
+        errExit("msgget - client message queue");
+
+    if (atexit(removeQueue) != 0)
+        errExit("atexit");
+
+    /* Send message asking for file named in argv[1] */
+
+    req.mtype = 1;                      /* Any type will do */
+    req.clientId = clientId;
+    strncpy(req.pathname, argv[1], sizeof(req.pathname) - 1);
+    req.pathname[sizeof(req.pathname) - 1] = '\0';
+                                        /* Ensure string is terminated */
+
+    if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1)
+        errExit("msgsnd");
+
+    /* Get first response, which may be failure notification */
+
+    msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
+    if (msgLen == -1)
+        errExit("msgrcv");
+
+    if (resp.mtype == RESP_MT_FAILURE) {
+        printf("%s\n", resp.data);      /* Display msg from server */
+        exit(EXIT_FAILURE);
+    }
+
+    /* File was opened successfully by server; process messages
+       (including the one already received) containing file data */
+
+    totBytes = msgLen;                  /* Count first message */
+    for (numMsgs = 1; resp.mtype == RESP_MT_DATA; numMsgs++) {
+        msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
+        if (msgLen == -1)
+            errExit("msgrcv");
+
+        totBytes += msgLen;
+    }
+
+    printf("Received %ld bytes (%d messages)\n", (long) totBytes, numMsgs);
+
+    exit(EXIT_SUCCESS);
+}

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -10,15 +10,54 @@
 
 /* svmsg_file_client.c
 
-   Send a message to the server svmsg_file_server.c requesting the
-   contents of the file named on the command line, and then receive the
-   file contents via a series of messages sent back by the server. Display
-   the total number of bytes and messages received. The server and client
-   communicate using System V message queues.
+   The server and client communicate using System V message queues.
+
+   This version of the application has been extensively modified based
+   on an initial version downloaded from:
+   https://man7.org/tlpi/code/online/all_files_by_chapter.html
+
+   Multiple clients can connect to a single server, which is receiving
+   messages on a specific server-queue-ID. Server will respond to each client
+   separately on its established client-queue-ID. [See svmsg_file_server.c]
+
+   Clients operation is simple:
+
+   - Send a message to the server containing an int64_t number
+   - Receive the number incremented / decremented by the server.
+   - Keep looping on this exchange for specified number of iterations.
+
+   The idea is to just have a fast message-exchange between the client
+   and the server and to measure the round-trip time. The actual work
+   done on the server-side is very little; just a number++ / number--.
+
+   We, then, inject L3-logging on the server-side, to record the
+   exchange with the client. The idea is to run this experiment with
+   L3-logging off (baseline) and compare average elapsed-time metrics
+   of round-trip of one message using a build where L3-logging code is
+   activated on the server side.
 */
+#include <stdlib.h>
+#include <inttypes.h>
+#include <time.h>
+
 #include "svmsg_file.h"
 
+// L3-LOC related headers
+#include "l3.h"
+
+// Useful constants
+#define L3_100K         ((uint32_t) (100 * 1000))
+#define L3_MILLION      ((uint32_t) (10 * L3_100K))
+#define L3_NS_IN_SEC    ((uint32_t) (1000 * 1000 * 1000))
+
 static int clientId;
+
+// Convert timespec value to nanoseconds units.
+static uint64_t inline
+timespec_to_ns(struct timespec *ts)
+{
+    return ((ts->tv_sec * L3_NS_IN_SEC) + ts->tv_nsec);
+}
 
 static void
 removeQueue(void)
@@ -31,23 +70,15 @@ removeQueue(void)
 int
 main(int argc, char *argv[])
 {
-    struct requestMsg req;
-    struct responseMsg resp;
-    int serverId, numMsgs;
-    ssize_t msgLen, totBytes;
+    ssize_t msgLen;
 
     if (argc != 2 || strcmp(argv[1], "--help") == 0) {
-        usageErr("%s pathname\n", argv[0]);
-    }
-
-    if (strlen(argv[1]) > sizeof(req.pathname) - 1) {
-        cmdLineErr("pathname too long (max: %ld bytes)\n",
-                (long) sizeof(req.pathname) - 1);
+        usageErr("%s <number-of-iterations>\n", argv[0]);
     }
 
     /* Get server's queue identifier; create queue for response */
 
-    serverId = msgget(SERVER_KEY, S_IWUSR);
+    int serverId = msgget(SERVER_KEY, S_IWUSR);
     if (serverId == -1) {
         errExit("msgget - server message queue");
     }
@@ -61,44 +92,99 @@ main(int argc, char *argv[])
         errExit("atexit");
     }
 
-    /* Send message asking for file named in argv[1] */
+    size_t niters = atoi(argv[1]);
+    printf("Client: ID=%d Perform %lu message-exchanges to increment a number"
+#if L3_ENABLED
+           ", with L3-logging enabled on server-side"
+#endif // L3_ENABLED
+           ".\n", clientId, niters);
 
-    req.mtype = 1;                      /* Any type will do */
-    req.clientId = clientId;
-    strncpy(req.pathname, argv[1], sizeof(req.pathname) - 1);
-    req.pathname[sizeof(req.pathname) - 1] = '\0';
-                                        /* Ensure string is terminated */
+    requestMsg req;
+    req.mtype       = REQ_MT_INIT;     // New client is establishing a connection
+    req.clientId    = clientId;
+    req.client_idx  = REQ_CLIENT_INDEX_UNKNOWN;
+    req.counter     = 0;
 
     if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1) {
         errExit("msgsnd");
     }
 
-    /* Get first response, which may be failure notification */
-
+    responseMsg resp;
     msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
     if (msgLen == -1) {
         errExit("msgrcv");
     }
 
     if (resp.mtype == RESP_MT_FAILURE) {
-        printf("%s\n", resp.data);      /* Display msg from server */
+        /* Display msg from server */
+        printf("Counter=%" PRIu64 "\n", resp.counter);
         exit(EXIT_FAILURE);
     }
 
-    /* File was opened successfully by server; process messages
-       (including the one already received) containing file data
-    */
-    totBytes = msgLen;                  /* Count first message */
-    for (numMsgs = 1; resp.mtype == RESP_MT_DATA; numMsgs++) {
-        msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
+    // Re-establish client's identity as obtained from the server.
+    req.client_idx = resp.client_idx;
+
+    /* Loop around for requested # of iterations, or till the time the
+     * server informs us to quit. (We implement receiving REQ_MT_QUIT from
+     * the server, but that is not happening right now.)
+     */
+    size_t ictr;
+
+    // Msg-round trip timing measurements for each msgsend/recv() pair.
+    struct timespec ts0;
+    struct timespec ts1;
+    uint64_t        elapsed_ns = 0;
+
+    for (ictr = 0; ictr < niters; ictr++) {
+
+        if ((ictr % L3_100K) == 0) {
+            printf(".");
+            fflush(stdout);
+        }
+        req.counter = resp.counter;
+        req.mtype = REQ_MT_INCR;
+
+        if (clock_gettime(CLOCK_REALTIME, &ts0)) {              // Timing begins
+            errExit("clock_gettime-ts0");
+        }
+
+        if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1) {    // --> Send
+            errExit("msgsnd");
+        }
+
+        msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);  // <-- Recv
+        if (clock_gettime(CLOCK_REALTIME, &ts1)) {              // Timing ends
+            errExit("clock_gettime-ts1");
+        }
         if (msgLen == -1) {
             errExit("msgrcv");
         }
 
-        totBytes += msgLen;
+        if (resp.mtype == RESP_MT_FAILURE) {
+            /* Display msg from server */
+            printf("Counter=%" PRIu64 "\n", resp.counter);
+            exit(EXIT_FAILURE);
+        }
+
+        uint64_t nsec0 = timespec_to_ns(&ts0);
+        uint64_t nsec1 = timespec_to_ns(&ts1);
+        elapsed_ns += (nsec1 - nsec0);
+
+        // Early-quit msg received from server
+        if (resp.mtype == REQ_MT_QUIT) {
+            break;
+        }
     }
 
-    printf("Received %ld bytes (%d messages)\n", (long) totBytes, numMsgs);
+    printf("Client: ID=%d Performed %lu message send/receive operations"
+           ", ctr=%" PRIu64 ", %" PRIu64 " ns/msg (avg) Exiting.\n",
+            clientId, ictr, resp.counter,
+            (elapsed_ns / ictr));
+
+    req.mtype = REQ_MT_EXIT;
+    if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1) {
+        errExit("msgsnd");
+    }
 
     exit(EXIT_SUCCESS);
 }

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -23,8 +23,9 @@ static int clientId;
 static void
 removeQueue(void)
 {
-    if (msgctl(clientId, IPC_RMID, NULL) == -1)
+    if (msgctl(clientId, IPC_RMID, NULL) == -1) {
         errExit("msgctl");
+    }
 }
 
 int
@@ -35,25 +36,30 @@ main(int argc, char *argv[])
     int serverId, numMsgs;
     ssize_t msgLen, totBytes;
 
-    if (argc != 2 || strcmp(argv[1], "--help") == 0)
+    if (argc != 2 || strcmp(argv[1], "--help") == 0) {
         usageErr("%s pathname\n", argv[0]);
+    }
 
-    if (strlen(argv[1]) > sizeof(req.pathname) - 1)
+    if (strlen(argv[1]) > sizeof(req.pathname) - 1) {
         cmdLineErr("pathname too long (max: %ld bytes)\n",
                 (long) sizeof(req.pathname) - 1);
+    }
 
     /* Get server's queue identifier; create queue for response */
 
     serverId = msgget(SERVER_KEY, S_IWUSR);
-    if (serverId == -1)
+    if (serverId == -1) {
         errExit("msgget - server message queue");
+    }
 
-    clientId = msgget(IPC_PRIVATE, S_IRUSR | S_IWUSR | S_IWGRP);
-    if (clientId == -1)
+    clientId = msgget(IPC_PRIVATE, (S_IRUSR | S_IWUSR | S_IWGRP));
+    if (clientId == -1) {
         errExit("msgget - client message queue");
+    }
 
-    if (atexit(removeQueue) != 0)
+    if (atexit(removeQueue) != 0) {
         errExit("atexit");
+    }
 
     /* Send message asking for file named in argv[1] */
 
@@ -63,14 +69,16 @@ main(int argc, char *argv[])
     req.pathname[sizeof(req.pathname) - 1] = '\0';
                                         /* Ensure string is terminated */
 
-    if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1)
+    if (msgsnd(serverId, &req, REQ_MSG_SIZE, 0) == -1) {
         errExit("msgsnd");
+    }
 
     /* Get first response, which may be failure notification */
 
     msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
-    if (msgLen == -1)
+    if (msgLen == -1) {
         errExit("msgrcv");
+    }
 
     if (resp.mtype == RESP_MT_FAILURE) {
         printf("%s\n", resp.data);      /* Display msg from server */
@@ -78,13 +86,14 @@ main(int argc, char *argv[])
     }
 
     /* File was opened successfully by server; process messages
-       (including the one already received) containing file data */
-
+       (including the one already received) containing file data
+    */
     totBytes = msgLen;                  /* Count first message */
     for (numMsgs = 1; resp.mtype == RESP_MT_DATA; numMsgs++) {
         msgLen = msgrcv(clientId, &resp, RESP_MSG_SIZE, 0, 0);
-        if (msgLen == -1)
+        if (msgLen == -1) {
             errExit("msgrcv");
+        }
 
         totBytes += msgLen;
     }

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -34,8 +34,9 @@ grimReaper(int sig)
     int savedErrno;
 
     savedErrno = errno;                 /* waitpid() might change 'errno' */
-    while (waitpid(-1, NULL, WNOHANG) > 0)
+    while (waitpid(-1, NULL, WNOHANG) > 0) {
         continue;
+    }
     errno = savedErrno;
 }
 
@@ -55,12 +56,14 @@ serveRequest(const struct requestMsg *req)
     }
 
     /* Transmit file contents in messages with type RESP_MT_DATA. We don't
-       diagnose read() and msgsnd() errors since we can't notify client. */
-
+       diagnose read() and msgsnd() errors since we can't notify client.
+    */
     resp.mtype = RESP_MT_DATA;
-    while ((numRead = read(fd, resp.data, RESP_MSG_SIZE)) > 0)
-        if (msgsnd(req->clientId, &resp, numRead, 0) == -1)
+    while ((numRead = read(fd, resp.data, RESP_MSG_SIZE)) > 0) {
+        if (msgsnd(req->clientId, &resp, numRead, 0) == -1) {
             break;
+        }
+    }
 
     /* Send a message of type RESP_MT_END to signify end-of-file */
 
@@ -79,26 +82,29 @@ main(int argc, char *argv[])
 
     /* Create server message queue */
 
-    serverId = msgget(SERVER_KEY, IPC_CREAT | IPC_EXCL |
-                            S_IRUSR | S_IWUSR | S_IWGRP);
-    if (serverId == -1)
+    serverId = msgget(SERVER_KEY,
+                      (IPC_CREAT | IPC_EXCL | S_IRUSR | S_IWUSR | S_IWGRP));
+    if (serverId == -1) {
         errExit("msgget");
+    }
 
     /* Establish SIGCHLD handler to reap terminated children */
 
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART;
     sa.sa_handler = grimReaper;
-    if (sigaction(SIGCHLD, &sa, NULL) == -1)
+    if (sigaction(SIGCHLD, &sa, NULL) == -1) {
         errExit("sigaction");
+    }
 
     /* Read requests, handle each in a separate child process */
 
     for (;;) {
         msgLen = msgrcv(serverId, &req, REQ_MSG_SIZE, 0, 0);
         if (msgLen == -1) {
-            if (errno == EINTR)         /* Interrupted by SIGCHLD handler? */
+            if (errno == EINTR) {       /* Interrupted by SIGCHLD handler? */
                 continue;               /* ... then restart msgrcv() */
+            }
             errMsg("msgrcv");           /* Some other error */
             break;                      /* ... so terminate loop */
         }
@@ -119,7 +125,8 @@ main(int argc, char *argv[])
 
     /* If msgrcv() or fork() fails, remove server MQ and exit */
 
-    if (msgctl(serverId, IPC_RMID, NULL) == -1)
+    if (msgctl(serverId, IPC_RMID, NULL) == -1) {
         errExit("msgctl");
+    }
     exit(EXIT_SUCCESS);
 }

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -1,0 +1,125 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU General Public License as published by the   *
+* Free Software Foundation, either version 3 or (at your option) any      *
+* later version. This program is distributed without any warranty.  See   *
+* the file COPYING.gpl-v3 for details.                                    *
+\*************************************************************************/
+
+/* svmsg_file_server.c
+
+   A file server that uses System V message queues to handle client requests
+   (see svmsg_file_client.c). The client sends an initial request containing
+   the name of the desired file, and the identifier of the message queue to be
+   used to send the file contents back to the child. The server attempts to
+   open the desired file. If the file cannot be opened, a failure response is
+   sent to the client, otherwise the contents of the requested file are sent
+   in a series of messages.
+
+   This application makes use of multiple message queues. The server maintains
+   a queue (with a well-known key) dedicated to incoming client requests. Each
+   client creates its own private queue, which is used to pass response
+   messages from the server back to the client.
+
+   This program operates as a concurrent server, forking a new child process to
+   handle each client request while the parent waits for further client requests.
+*/
+#include "svmsg_file.h"
+
+static void             /* SIGCHLD handler */
+grimReaper(int sig)
+{
+    int savedErrno;
+
+    savedErrno = errno;                 /* waitpid() might change 'errno' */
+    while (waitpid(-1, NULL, WNOHANG) > 0)
+        continue;
+    errno = savedErrno;
+}
+
+static void             /* Executed in child process: serve a single client */
+serveRequest(const struct requestMsg *req)
+{
+    int fd;
+    ssize_t numRead;
+    struct responseMsg resp;
+
+    fd = open(req->pathname, O_RDONLY);
+    if (fd == -1) {                     /* Open failed: send error text */
+        resp.mtype = RESP_MT_FAILURE;
+        snprintf(resp.data, sizeof(resp.data), "%s", "Couldn't open");
+        msgsnd(req->clientId, &resp, strlen(resp.data) + 1, 0);
+        exit(EXIT_FAILURE);             /* and terminate */
+    }
+
+    /* Transmit file contents in messages with type RESP_MT_DATA. We don't
+       diagnose read() and msgsnd() errors since we can't notify client. */
+
+    resp.mtype = RESP_MT_DATA;
+    while ((numRead = read(fd, resp.data, RESP_MSG_SIZE)) > 0)
+        if (msgsnd(req->clientId, &resp, numRead, 0) == -1)
+            break;
+
+    /* Send a message of type RESP_MT_END to signify end-of-file */
+
+    resp.mtype = RESP_MT_END;
+    msgsnd(req->clientId, &resp, 0, 0);         /* Zero-length mtext */
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct requestMsg req;
+    pid_t pid;
+    ssize_t msgLen;
+    int serverId;
+    struct sigaction sa;
+
+    /* Create server message queue */
+
+    serverId = msgget(SERVER_KEY, IPC_CREAT | IPC_EXCL |
+                            S_IRUSR | S_IWUSR | S_IWGRP);
+    if (serverId == -1)
+        errExit("msgget");
+
+    /* Establish SIGCHLD handler to reap terminated children */
+
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    sa.sa_handler = grimReaper;
+    if (sigaction(SIGCHLD, &sa, NULL) == -1)
+        errExit("sigaction");
+
+    /* Read requests, handle each in a separate child process */
+
+    for (;;) {
+        msgLen = msgrcv(serverId, &req, REQ_MSG_SIZE, 0, 0);
+        if (msgLen == -1) {
+            if (errno == EINTR)         /* Interrupted by SIGCHLD handler? */
+                continue;               /* ... then restart msgrcv() */
+            errMsg("msgrcv");           /* Some other error */
+            break;                      /* ... so terminate loop */
+        }
+
+        pid = fork();                   /* Create child process */
+        if (pid == -1) {
+            errMsg("fork");
+            break;
+        }
+
+        if (pid == 0) {                 /* Child handles request */
+            serveRequest(&req);
+            _exit(EXIT_SUCCESS);
+        }
+
+        /* Parent loops to receive next client request */
+    }
+
+    /* If msgrcv() or fork() fails, remove server MQ and exit */
+
+    if (msgctl(serverId, IPC_RMID, NULL) == -1)
+        errExit("msgctl");
+    exit(EXIT_SUCCESS);
+}

--- a/use-cases/client-server-msgs-perf/tlpi_hdr.h
+++ b/use-cases/client-server-msgs-perf/tlpi_hdr.h
@@ -1,0 +1,82 @@
+/*************************************************************************\
+*                  Copyright (C) Michael Kerrisk, 2024.                   *
+*                                                                         *
+* This program is free software. You may use, modify, and redistribute it *
+* under the terms of the GNU Lesser General Public License as published   *
+* by the Free Software Foundation, either version 3 or (at your option)   *
+* any later version. This program is distributed without any warranty.    *
+* See the files COPYING.lgpl-v3 and COPYING.gpl-v3 for details.           *
+\*************************************************************************/
+
+/* tlpi_hdr.h
+
+   Standard header file used by nearly all of our example programs.
+*/
+#ifndef TLPI_HDR_H
+#define TLPI_HDR_H      /* Prevent accidental double inclusion */
+
+#include <sys/types.h>  /* Type definitions used by many programs */
+#include <stdio.h>      /* Standard I/O functions */
+#include <stdlib.h>     /* Prototypes of commonly used library functions,
+                           plus EXIT_SUCCESS and EXIT_FAILURE constants */
+#include <unistd.h>     /* Prototypes for many system calls */
+#include <errno.h>      /* Declares errno and defines error constants */
+#include <string.h>     /* Commonly used string-handling functions */
+#include <stdbool.h>    /* 'bool' type plus 'true' and 'false' constants */
+
+#include "get_num.h"    /* Declares our functions for handling numeric
+                           arguments (getInt(), getLong()) */
+
+#include "error_functions.h"  /* Declares our error-handling functions */
+
+/* Unfortunately some UNIX implementations define FALSE and TRUE -
+   here we'll undefine them */
+
+#ifdef TRUE
+#undef TRUE
+#endif
+
+#ifdef FALSE
+#undef FALSE
+#endif
+
+typedef enum { FALSE, TRUE } Boolean;
+
+#define min(m,n) ((m) < (n) ? (m) : (n))
+#define max(m,n) ((m) > (n) ? (m) : (n))
+
+/* Some systems don't define 'socklen_t' */
+
+#if defined(__sgi)
+typedef int socklen_t;
+#endif
+
+#if defined(__sun)
+#include <sys/file.h>           /* Has definition of FASYNC */
+#endif
+
+#if ! defined(O_ASYNC) && defined(FASYNC)
+/* Some systems define FASYNC instead of O_ASYNC */
+#define O_ASYNC FASYNC
+#endif
+
+#if defined(MAP_ANON) && ! defined(MAP_ANONYMOUS)
+/* BSD derivatives usually have MAP_ANON, not MAP_ANONYMOUS */
+#define MAP_ANONYMOUS MAP_ANON
+
+#endif
+
+#if ! defined(O_SYNC) && defined(O_FSYNC)
+/* Some implementations have O_FSYNC instead of O_SYNC */
+#define O_SYNC O_FSYNC
+#endif
+
+#if defined(__FreeBSD__)
+
+/* FreeBSD uses these alternate names for fields in the sigval structure */
+
+#define sival_int sigval_int
+#define sival_ptr sigval_ptr
+#endif
+
+#endif


### PR DESCRIPTION
This PR is a collection of multiple commits that incrementally build a client/server messaging program for use as a performance exerciser to measure overheads of L3/LOC diagnostic.

1. Initial version of client-server IPC msgs program sources.
2. Cleanup code-formatting in client-server IPC msgs program sources.
3. [Perf] Develop client-server comms. program to measure L3-logging overheads

-----

### Initial version of client-server IPC msgs program sources.

This commit adds the initial version of client-server messaging program sources as downloaded from Michael Kerrisk's reference book "The Linux Programming Interface".

Ref: https://man7.org/tlpi/code/online/all_files_by_chapter.html
Ch. 46: System V Message Queues.

Ref: git@github.com:bradfa/tlpi-dist.git

Required header files, along with the two main source files, svmsg_file_client.c and svmsg_file_server.c, are checked-in.

Makefile is updated to add the `client-server-perf-test` target which will build the client/server programs. Currently, as the server runs in an endless loop, we just build these programs but do not exercise these programs as part of CI.

Follow-on commits will adapt these core programs to develop a L3-LOC performance test exerciser.

### Cleanup code-formatting in client-server IPC msgs program sources.

Tighten code-formatting in `.c` sources for client-server program sources inherited in previous commit.

- Consistently enclose single-line body of `if()`, `else()` conditionals in { }, to avoid any errors creeping-in due to future refactoring.
- Re-indent end `*/` markers of multi-line comment blocks to start on a newline.
- Enclose multiple `|`-separated status flags in `()`

No code-logic change is introduced with this commit.

----

### [Perf] Develop client-server comms. program to measure L3-logging overheads

This commit simplifies the simple client-server communication program to be usable as a performance test-bed to quantify the overheads of L3-logging. Basic single/multiple-clients exchanging n-messages with server
that runs in serial manner (of processing messages) is working with this [3rd] commit.

The changes are as follows:

`svmsg_file.h`:
  - Define enum req_resp_type_t{} with few message types.
  - Specifically of interest are: REQ_MT_INIT, REQ_MT_INCR, REQ_MT_EXIT

`svmsg_file_server.c`
  - Simplified server. Receives messages inline from client in a forever loop. Currently, only implements "increment" counter.
  - Manages state of multiple client connections using simple array
  - L3-logging code is conditionally defined under L3_ENABLED. So, will need to build separately to invoke-and-test logging overheads.

`svmsg_file_client.c`
  - Sits in forever loop, sending "increment" message to server
  - Do this for n-iterations.

`Makefile`: Make changes to build the client/server programs with L3-logging OFF (baseline) and logging enabled.

`test.sh`: Add test-build-and-run-client-server-perf-test and include that in CI's build.yml . We will build-and-run a small scale run of this new test, with 5 concurrent clients, L3 ON and OFF.

-----

## Manual testing output

Here is how things will look when running this client-server application with a build where L3-Logging is enabled:

#### Server:

```
agurajada-Linux-Vm:[155] $ build/release/bin/use-cases/svmsg_file_server

Server: Initiate L3-logging to log-file '/tmp/l3.c-server-test.dat'                <<<<<
Server: Client ID=196636 joined. # active clients=1 (HWM=1)
Server: Client ID=196636 exited. # active clients=0
Server: # active clients=0 (HWM=1). Exiting.
```

#### Client:

```
agurajada-Linux-Vm:[815] $ build/release/bin/use-cases/svmsg_file_client 1000000
Client: ID=196636 Perform 1000000 message-exchanges to increment a number, 
with L3-logging enabled on server-side.         
^^^^^ Note msg reports that build is such that L3-logging code is active on server-side
..........
Client: ID=196636 Performed 1000000 message send/receive operations, ctr=1000000, 47476 ns/msg (avg) Exiting.
```