### PR TITLE
[Perf] Extend Client-server perf tests to run with L3_LOC_ENABLED

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,14 @@ jobs:
       run: |
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_1
 
+    #! -------------------------------------------------------------------------
+    #  This test will build-and-run client-server perf-test, with L3-Logging
+    #  ON + L3-LOC-ELF encoding scheme ON.
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-client-server-perf-test-l3_loc_eq_2
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_2
+
     # -------------------------------------------------------------------------
     # Exercise the --from-test interface to verify that it still works to
     # run thru last pair of code-formatting tests. (Minor duplication of

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,9 +163,20 @@ jobs:
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-Cc-samples-with-LOC-ELF
 
     #! -------------------------------------------------------------------------
+    #  This test will build-and-run client-server perf-test, with L3-Logging OFF
+    #  (baseline) and L3-Logging ON.
+    #! -------------------------------------------------------------------------
     - name: test-build-and-run-client-server-perf-test
       run: |
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test
+
+    #! -------------------------------------------------------------------------
+    #  This test will build-and-run client-server perf-test, with L3-Logging
+    #  ON + L3-LOC encoding scheme ON.
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-client-server-perf-test-l3_loc_eq_1
+      run: |
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_1
 
     # -------------------------------------------------------------------------
     # Exercise the --from-test interface to verify that it still works to

--- a/Makefile
+++ b/Makefile
@@ -551,6 +551,13 @@ ifeq ($(L3_ENABLED), $(L3_DEFAULT))
     CLIENT_SERVER_NON_MAIN_SRCS += $(L3_SRC)
 endif
 
+# Name of LOC-generated source file for the client-server perf-test program.
+ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))
+
+    CLIENT_SERVER_PROGRAM_GENSRC := $(CLIENT_SERVER_PERF_TESTS_DIR)/$(LOC_FILENAMES)
+    CLIENT_SERVER_NON_MAIN_SRCS  += $(CLIENT_SERVER_PROGRAM_GENSRC)
+endif
+
 # Map the list of sources to resulting list-of-objects
 CLIENT_SERVER_CLIENT_MAIN_OBJ   := $(CLIENT_SERVER_CLIENT_MAIN_SRC:%.c=$(OBJDIR)/%.o)
 CLIENT_SERVER_SERVER_MAIN_OBJ   := $(CLIENT_SERVER_SERVER_MAIN_SRC:%.c=$(OBJDIR)/%.o)
@@ -580,7 +587,13 @@ endif
 $(BINDIR)/$(USE_CASES)/svmsg_file_client: $(CLIENT_SERVER_CLIENT_MAIN_OBJ) $(CLIENT_SERVER_NON_MAIN_OBJS)
 $(BINDIR)/$(USE_CASES)/svmsg_file_server: $(CLIENT_SERVER_SERVER_MAIN_OBJ) $(CLIENT_SERVER_NON_MAIN_OBJS)
 
-client-server-perf-test: $(CLIENT_SERVER_PERF_TEST_BINS)
+$(CLIENT_SERVER_PROGRAM_GENSRC): | $(BINDIR)/$(USE_CASES)/.
+	@echo
+	@echo "Invoke LOC-generator triggered by: " $@
+	@$(LOCGENPY) --gen-includes-dir  $(L3_INCDIR) --gen-source-dir $(dir $@) --src-root-dir $(dir $@) --loc-decoder-dir $(BINDIR)/$(USE_CASES) --verbose
+	@echo
+
+client-server-perf-test: $(CLIENT_SERVER_PROGRAM_GENSRC) $(CLIENT_SERVER_PERF_TEST_BINS)
 
 # ##############################################################################
 # CFLAGS, LDFLAGS, ETC
@@ -619,6 +632,7 @@ ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))
     LDFLAGS += -DL3_LOC_ENABLED
 
 else ifeq ($(L3_LOC_ENABLED), $(L3_LOC_ELF_ENCODING))
+    # Core L3 files flag off of L3_LOC_ENABLED.
     CFLAGS += -DL3_LOC_ENABLED
     LDFLAGS += -DL3_LOC_ENABLED
 

--- a/Makefile
+++ b/Makefile
@@ -556,6 +556,12 @@ ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))
 
     CLIENT_SERVER_PROGRAM_GENSRC := $(CLIENT_SERVER_PERF_TESTS_DIR)/$(LOC_FILENAMES)
     CLIENT_SERVER_NON_MAIN_SRCS  += $(CLIENT_SERVER_PROGRAM_GENSRC)
+
+else ifeq ($(L3_LOC_ENABLED), $(L3_LOC_ELF_ENCODING))
+
+    # If L3-LOC_ELF encoding is chosen, link with system-provided loc.c
+    CLIENT_SERVER_NON_MAIN_SRCS += $(LOC_ELF_SRC)
+
 endif
 
 # Map the list of sources to resulting list-of-objects
@@ -632,8 +638,15 @@ ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))
     LDFLAGS += -DL3_LOC_ENABLED
 
 else ifeq ($(L3_LOC_ENABLED), $(L3_LOC_ELF_ENCODING))
+
     # Core L3 files flag off of L3_LOC_ENABLED.
     CFLAGS += -DL3_LOC_ENABLED
+
+    # Core L3 files flag off of L3_LOC_ENABLED. L3_LOC_ELF_ENABLED is provided
+    # in case in some sources we wish to conditionally compile some info-msgs
+    # indicating that this LOC-ELF encoding scheme is in effect.
+    CFLAGS += -DL3_LOC_ENABLED -DL3_LOC_ELF_ENABLED
+
     LDFLAGS += -DL3_LOC_ENABLED
 
 endif

--- a/l3_dump.py
+++ b/l3_dump.py
@@ -46,7 +46,7 @@ elif OS_UNAME_S == 'Darwin':
     READELF_DATA_SECTION = '__cstring'
 
 # #############################################################################
-def set_decode_loc_id(program_bin:str, loc_decoder_bin:str):
+def set_decode_loc_id(program_bin:str, loc_decoder_bin:str = None):
     """
     Check for required LOC-decoder binary, based on environment of run.
     If L3_LOC_ENABLED=1 is set in the env:

--- a/test.sh
+++ b/test.sh
@@ -75,6 +75,7 @@ TestList=(
 
            "test-build-and-run-client-server-perf-test"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
+           "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
 
            "test-pytests"
 
@@ -326,6 +327,36 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_1()
                         --log-file /tmp/l3.c-server-test.dat                                \
                         --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
                         --loc-binary "./build/${Build_mode}/bin/use-cases/client-server-msgs-perf_loc" \
+                | tail -${nentries}
+
+    echo " "
+    echo "${Me}: Completed basic client(s)-server communication test."
+    echo " "
+}
+
+# #############################################################################
+# Test build-and-run of client-server performance test benchmark.
+# This test-case runs with L3-logging and L3-ELF scheme enabled.
+# #############################################################################
+function test-build-and-run-client-server-perf-test-l3_loc_eq_2()
+{
+    set +x
+
+    echo " "
+    echo "${Me}: Client-server performance testing with L3-logging and LOC-ELF ON:"
+    echo " "
+    build-and-run-client-server-perf-test 1 2
+
+    local nentries=100
+    echo " "
+    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+    echo " "
+
+    # Currently, we are not unpacking LOC-ELF-IDs, so, for dumping this kind
+    # of logging, we don't need the --loc-binary argument.
+    L3_LOC_ENABLED=2 ./l3_dump.py                                                           \
+                        --log-file /tmp/l3.c-server-test.dat                                \
+                        --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
                 | tail -${nentries}
 
     echo " "

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -121,7 +121,11 @@ main(int argc, char *argv[])
     if (e) {
         errExit("l3_init");
     }
-    printf("Server: Initiate L3-logging to log-file '%s'\n", logfile);
+
+    const char *loc_scheme = "LOC";
+    printf("Server: Initiate L3-logging to log-file '%s'"
+           ", using %s encoding scheme.\n", logfile, loc_scheme);
+
 #endif // L3_ENABLED
 
     /* Read requests, handle each in a separate child process */

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -122,7 +122,13 @@ main(int argc, char *argv[])
         errExit("l3_init");
     }
 
+    // Info-message to track how L3-logging is being done by server.
+#if L3_LOC_ELF_ENABLED
+    const char *loc_scheme = "LOC-ELF";
+#else
     const char *loc_scheme = "LOC";
+#endif  // L3_LOC_ELF_ENCODING
+
     printf("Server: Initiate L3-logging to log-file '%s'"
            ", using %s encoding scheme.\n", logfile, loc_scheme);
 


### PR DESCRIPTION
This PR packages two commits to integrate L3-logging invoked by the client-server performance test programs to now also invoke LOC-encoding as part of L3-Logging. The changes are mainly in `Makefile` with simple additions to `test.sh` and to `build.yml` to run these new changes thru CI.

1. [Perf] Makefile support to build client-server perf programs w/LOC encoding
2. [Perf] Makefile support to build client-server perf programs w/LOC-ELF

------

### 1. [Perf] Makefile support to build client-server perf programs w/LOC encoding

This commit implements Makefile rules to build the client-server programs such that L3-logging is performed with default LOC-encoding.

`./test.sh` : Add test-build-and-run-client-server-perf-test-l3_loc_eq_1 which is also invoked thru a call in CI build.yml

This test-case will run the client/server app and then will invoke the `l3_dump.py` to unpack the L3-log entries, with LOC-ID decoded.

As the LOC-generator, by default, spits out the LOC-decoder with the name of the dir/ it is searching, we need a way to specify the LOC-decoder binary to be used when dumping L3 log-entries.

`l3_dump.py` is now extended to support `--loc-binary` argument to specify the name of the LOC-decoder binary to use. (This feature is useful even by itself outside this very test-specific usage.)

To test this manually do:

```
$ make clean && CC=gcc LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=1 make client-server-perf-test

$ build/release/bin/use-cases/svmsg_file_server

$ build/release/bin/use-cases/svmsg_file_client 10

$ L3_LOC_ENABLED=1 ./l3_dump.py --log-file /tmp/l3.c-server-test.dat --binary build/release/bin/use-cases/svmsg_file_server --loc-binary build/release/bin/use-cases/client-server-msgs-perf_loc
```


----

### 2. [Perf] Makefile support to build client-server perf programs w/LOC-ELF encoding

This commit implements Makefile rules to build the client-server programs such that L3-logging is performed with enhanced LOC-ELF encoding.

`./test.sh` : Add `test-build-and-run-client-server-perf-test-l3_loc_eq_2`  which is also invoked thru a call in CI build.yml

This test-case will run the client/server app and then will invoke the `l3_dump.py` to unpack the L3-log entries. (Currently we still don't support decoding LOC-IDs encoded with LOC-ELF scheme.)

To test this manually do:

```
$ make clean && CC=gcc LD=g++ BUILD_VERBOSE=1 L3_LOC_ENABLED=2 make client-server-perf-test

$ build/release/bin/use-cases/svmsg_file_server

$ build/release/bin/use-cases/svmsg_file_client 10

$ L3_LOC_ENABLED=2 ./l3_dump.py --log-file /tmp/l3.c-server-test.dat --binary build/release/bin/use-cases/svmsg_file_server
```