### PR TITLE
Formalize L3-log header. Add status flags. Remove dependence on env-variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -639,9 +639,6 @@ ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))
 
 else ifeq ($(L3_LOC_ENABLED), $(L3_LOC_ELF_ENCODING))
 
-    # Core L3 files flag off of L3_LOC_ENABLED.
-    CFLAGS += -DL3_LOC_ENABLED
-
     # Core L3 files flag off of L3_LOC_ENABLED. L3_LOC_ELF_ENABLED is provided
     # in case in some sources we wish to conditionally compile some info-msgs
     # indicating that this LOC-ELF encoding scheme is in effect.


### PR DESCRIPTION
Rework L3 log-file header to identify type of logging done.

This commit overhauls the L3_LOG{} header struct at the head of a L3-logfile. Several changes are introduced to make the handling of log-files a bit more robust, and independent of environment
variables.

l3.c:
     - Add enum l3_log_flags_t, to specify bit-flags to track type of logging in this log-file
     - Rearrange L3_LOG{} to include `l3_log_flags_t  flags` field.
     - Record the type of LOC-encoding used, which is determined as part of the build.

l3_dump.py:
     - Add l3_unpack_loghdr() to figure out the type of LOC-encoding present, if any, in the log-entries.
     - Rework identification of LOC-decode binary to use, without relying on environment variables.
        If the Log header indicates that `LOC_DEFAULT` is in effect (i.e., the application was built
       with `L3_LOC_ENABLED=1` env-var), then the dump utility will expect to find a corresponding
        LOC-decoder utility at a known location.
       If not, user has to supply one using the `--loc-binary` argument.
    - Remove dependency on os.environ() to figure out if LOC-decoding should be done.

l3_dump_test.py:
 - Cleaned-up test cases to no longer rely on OS env-variables to
   figure out the setting of L3_LOC_ENABLED when dumping a log-file.

 - With this change, existing verify_l3_dump_unpack() can nicely call
   into newly added l3_dump.l3_unpack_loghdr(), to figure the LOC-encoding
   scheme in-effect in log-file being dumped.

 - Fixed few minor testcase bugs.

-----

### NOTE about status flags added:

We record the platform (Linux, Mac/OSX) on which the logging was done. In future revs, this provides a place where we can cross-check that dumping on Mac/OSX a log-file that was generated on Linux, or vice-versa, can be checked-for and prevented.

Also, a magic field has been added, but it's not being used right now. In future, this will provide a place to add some magic number checking to ensure that `l3_dump.py` does not error out when presented  a file which is not a L3-log-file.
