### PR TITLE
[Py] Extend L3-dump utility to generate C-printf()'ed output

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -323,11 +323,14 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_1()
     echo " "
     echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
     echo " "
+    set -x
     L3_LOC_ENABLED=1 ./l3_dump.py                                                           \
                         --log-file /tmp/l3.c-server-test.dat                                \
                         --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
                         --loc-binary "./build/${Build_mode}/bin/use-cases/client-server-msgs-perf_loc" \
                 | tail -${nentries}
+
+    set +x
 
     echo " "
     echo "${Me}: Completed basic client(s)-server communication test."

--- a/tests/unit/l3_dump.py-test.c
+++ b/tests/unit/l3_dump.py-test.c
@@ -46,10 +46,10 @@ void test_l3_slow_log(void)
     if (e) {
         abort();
     }
-    l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-    l3_log_simple("Simple-log-msg-Args(3,4)", 3, 4);
-    l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-    l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
+    l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
+    l3_log_simple("Simple-log-msg-Args(arg3=%d, arg4=%d)", 3, 4);
+    l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
+    l3_log_simple("Invalid buffer handle (addr=0x%x), lockrec=0x%p", 0xbeefabcd, 0);
 
     printf("Generated slow log-entries to log-file: %s\n", log);
 }
@@ -61,11 +61,11 @@ void test_l3_fast_log(void)
     if (e) {
         abort();
     }
-    l3_log_fast("Fast-log-msg: Args(1,2)", 1, 2);
-    l3_log_fast("Fast-log-msg: Args(3,4)", 3, 4);
-    l3_log_fast("Fast-log-msg: Args(10,20)", 10, 20);
-    l3_log_fast("Fast-log-msg: Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-    l3_log_fast("Fast-log-msg: Invalid buffer handle (addr)", 0xbeefabcd, 0);
+    l3_log_fast("Fast-log-msg: Args(arg1=%d, arg2=%d)", 1, 2);
+    l3_log_fast("Fast-log-msg: Args(arg3=%d, arg4=%d)", 3, 4);
+    l3_log_fast("Fast-log-msg: Args(arg1=%d, arg2=%d)", 10, 20);
+    l3_log_fast("Fast-log-msg: Potential memory overwrite (addr=0x%x, size=%lu)", 0xdeadbabe, 1024);
+    l3_log_fast("Fast-log-msg: Invalid buffer handle (addr=0x%p), unused=%lu", 0xbeefabcd, 0);
 
     printf("Generated fast log-entries to log-file: %s\n", log);
 }

--- a/use-cases/single-file-C-program/test-main.c
+++ b/use-cases/single-file-C-program/test-main.c
@@ -73,11 +73,11 @@ main(const int argc, const char * argv[])
             abort();
         }
         printf("L3-logging unit-tests log file: %s\n", logfile);
-        l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2", 20, 0xbeefbabe);
+        l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
+        l3_log_simple("Invalid buffer handle (addr=%p), refcount=%d", 0xbeefabcd, 0);
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
     }
 
     return 0;
@@ -94,7 +94,7 @@ test_perf_slow_logging(int nMil)
 
     uint32_t n = 0;
     for (n = 0; n < (nMil * L3_MILLION); n++) {
-        l3_log_simple("Perf-300-Mil Simple l3-log msgs", n, 0);
+        l3_log_simple("Perf-300-Mil Simple l3-log msgs, ctr=%d, value=%d", n, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {
@@ -117,7 +117,7 @@ test_perf_fast_logging(int nMil)
     }
     uint32_t n = 0;
     for (n = 0; n < (nMil * L3_MILLION); n++) {
-        l3_log_fast("Perf-300-Mil Fast l3-log msgs", n, 0);
+        l3_log_fast("Perf-300-Mil Fast l3-log msgs, ctr=%d, value=%d", n, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {

--- a/use-cases/single-file-CC-program/test-main.cc
+++ b/use-cases/single-file-CC-program/test-main.cc
@@ -64,11 +64,11 @@ main(const int argc, const char * argv[])
             abort();
         }
         cout << "L3-logging unit-tests log file: " << logfile << "\n";
-        l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2", 20, 0xbeefbabe);
+        l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%u)", 0xdeadbabe, 1024);
+        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", 0xbeefabcd, 0);
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
     }
 
     return 0;
@@ -85,7 +85,7 @@ test_perf_slow_logging(int nMil)
 
     auto n = 0;
     for (; n < (nMil * L3_MILLION); n++) {
-        l3_log_simple("Perf-300-Mil Simple l3-log msgs", 0, 0);
+        l3_log_simple("Perf-300-Mil Simple l3-log msgs, i=%d, j=%d", 0, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {
@@ -110,7 +110,8 @@ test_perf_fast_logging(int nMil)
     // Throw-in some variations to generate diff 'arg' values during logging.
     auto n = 0;
     for (; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("Perf-300-Mil Fast l3-log msgs", (n/L3_MILLION), n);
+        l3_log_fast("Perf-300-Mil Fast l3-log msgs, ctr=%d Mil, n=%d",
+                    (n/L3_MILLION), n);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {

--- a/use-cases/single-file-Cpp-program/test-main.cpp
+++ b/use-cases/single-file-Cpp-program/test-main.cpp
@@ -65,11 +65,11 @@ main(const int argc, const char * argv[])
             abort();
         }
         cout << "L3-logging unit-tests log file: " << logfile << "\n";
-        l3_log_simple("Simple-log-msg-Args(1,2)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr, size)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr)", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2", 20, 0xbeefbabe);
+        l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
+        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", 0xbeefabcd, 0);
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
     }
 
     return 0;
@@ -86,7 +86,7 @@ test_perf_slow_logging(int nMil)
 
     auto n = 0;
     for (; n < (nMil * L3_MILLION); n++) {
-        l3_log_simple("Perf-300-Mil Simple l3-log msgs", 0, 0);
+        l3_log_simple("Perf-300-Mil Simple l3-log msgs, i=%d, j=%d", 0, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {
@@ -111,7 +111,8 @@ test_perf_fast_logging(int nMil)
     // Throw-in some variations to generate diff 'arg' values during logging.
     auto n = 0;
     for (; n < (300 * L3_MILLION); n++) {
-        l3_log_fast("Perf-300-Mil Fast l3-log msgs", (n/L3_MILLION), n);
+        l3_log_fast("Perf-300-Mil Fast l3-log msgs, ctr=%d Mil, n=%d",
+                    (n/L3_MILLION), n);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {


### PR DESCRIPTION
This commit leverages an "old-style" Python print format to generate messages from the L3 log-file where 2 arguments are replaced in the users msg with embedded print-format specifiers.

We support most of the print specifiers Python supports:

- Massage the msg to replace '%p' -> '0x%x' as python does not support %p
- Fix %u, %lu and %llu handling. Add `test_fmtstr_replace_and_print()`
- Rework test-cases to cope with output messages with parameters replaced
- Fix all tests to work correctly with parameter substitution.
- Add `test_fmtstr_replace()`

A sample output from this change can be seen by running unit-tests to illustrate the benefit of this work:

    $ make clean && CC=gcc LD=g++ make run-unit-tests
    ----
    python3 l3_dump.py --log-file /tmp/l3.c-small-unit-test.dat --binary ./build/release/bin/unit/l3_dump.py-test
    tid=102888 'Simple-log-msg-Args(arg1=1, arg2=2)'
    tid=102888 'Simple-log-msg-Args(arg3=3, arg4=4)'
    tid=102888 'Potential memory overwrite (addr=0xdeadbabe, size=1024)'
    tid=102888 'Invalid buffer handle (addr=0xbeefabcd), lockrec=0x0'
    Unpacked nentries=4 log-entries.

    python3 l3_dump.py --log-file /tmp/l3.c-fast-unit-test.dat --binary ./build/release/bin/unit/l3_dump.py-test
    tid=102888 'Fast-log-msg: Args(arg1=1, arg2=2)'
    tid=102888 'Fast-log-msg: Args(arg3=3, arg4=4)'
    tid=102888 'Fast-log-msg: Args(arg1=10, arg2=20)'
    tid=102888 'Fast-log-msg: Potential memory overwrite (addr=0xdeadbabe, size=1024)'
    tid=102888 'Fast-log-msg: Invalid buffer handle (addr=0xbeefabcd), unused=0'
    Unpacked nentries=5 log-entries.
    ----

**Note**: The arguments to the log-entry are replaced in the output message.

        'Potential memory overwrite (addr=0xdeadbabe, size=1024)'