### PR TITLE
Fix bugs in client-server-perf-test msgs, and test-execution.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -357,6 +357,17 @@ function test-build-and-run-client-server-perf-test()
     echo " "
     build-and-run-client-server-perf-test 1
 
+    local nentries=100
+    echo " "
+    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+    echo " "
+
+    # No LOC-encoding is in-effect, so no need for the --loc-binary argument.
+    ./l3_dump.py                                                                \
+            --log-file /tmp/l3.c-server-test.dat                                \
+            --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
+        | tail -${nentries}
+
     echo " "
     echo "${Me}: Completed basic client(s)-server communication test."
     echo " "
@@ -442,7 +453,8 @@ function build-and-run-client-server-perf-test()
 
     set -x
     make clean \
-    && CXX=g++ LD=g++ L3_ENABLED=${l3_enabled} L3_LOC_ENABLED=${l3_loc_enabled} make client-server-perf-test
+    && CXX=g++ LD=g++ L3_ENABLED=${l3_enabled} L3_LOC_ENABLED=${l3_loc_enabled} BUILD_VERBOSE=1 \
+        make client-server-perf-test
 
     ${server_bin} &
 
@@ -450,11 +462,12 @@ function build-and-run-client-server-perf-test()
     sleep 5
 
     local numclients=5
+    local num_msgs_per_client=1000
     local ictr=0
     while [ ${ictr} -lt ${numclients} ]; do
 
         set -x
-        ${client_bin} 1000 &
+        ${client_bin} ${num_msgs_per_client} &
         set +x
 
         ictr=$((ictr + 1))

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -95,7 +95,17 @@ main(int argc, char *argv[])
     size_t niters = atoi(argv[1]);
     printf("Client: ID=%d Perform %lu message-exchanges to increment a number"
 #if L3_ENABLED
-           ", with L3-logging enabled on server-side"
+           ", with L3-logging"
+
+// In build -D L3_LOC_ELF_ENABLED and -D L3_LOC_ENABLED are both ON.
+// So, check in this order.
+#if L3_LOC_ELF_ENABLED
+           ", LOC-ELF encoding,"
+#elif L3_LOC_ENABLED
+           ", default LOC encoding,"
+#endif
+           " enabled on server-side"
+
 #endif // L3_ENABLED
            ".\n", clientId, niters);
 

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -122,11 +122,16 @@ main(int argc, char *argv[])
         errExit("l3_init");
     }
 
-    // Info-message to track how L3-logging is being done by server.
+// In build -D L3_LOC_ELF_ENABLED and -D L3_LOC_ENABLED are both ON.
+// So, check in this order.
+// Info-message to track how L3-logging is being done by server.
+
 #if L3_LOC_ELF_ENABLED
     const char *loc_scheme = "LOC-ELF";
+#elif L3_LOC_ENABLED
+    const char *loc_scheme = "default LOC";
 #else
-    const char *loc_scheme = "LOC";
+    const char *loc_scheme = "(no LOC)";
 #endif  // L3_LOC_ELF_ENCODING
 
     printf("Server: Initiate L3-logging to log-file '%s'"
@@ -186,8 +191,7 @@ main(int argc, char *argv[])
             clientp->last_mtype = REQ_MT_INCR;
             resp.counter = ++clientp->client_ctr;
 #if L3_ENABLED
-            l3_log_simple("ClientID=%d, Increment=%" PRIu64,
-                          resp.clientId, resp.counter);
+            l3_log_simple("Server msg: ClientID=%d, Increment=%" PRIu64, resp.clientId, resp.counter);
 #endif // L3_ENABLED
             break;
 


### PR DESCRIPTION
This commit does some clean-up in the build-steps and test.sh execution steps for the client-server-perf-test exerciser sources:

`test.sh`:
  - In `test-build-and-run-client-server-perf-test()`, invoke `l3_dump.py` script for the run with plain L3-logging enabled.

`svmsg_file_server.c`:
  - Fix `char * loc_scheme` to be  "(no LOC)" for the case when LOC is not ON.
  - Re-indent log call to be on one-line, to match-up line # more easily.

`svmsg_file_client.c`, `svmsg_file_server.c`:
  - Consistently report 'default LOC' or 'LOC-ELF' encoding in msgs, depending on which of -D L3_LOC_ELF_ENABLED or -D L3_LOC_ENABLED was active during the build..