### PR TITLE
[Perf] Track thread-CPU-time for each request on server-side.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help::
 	@echo ' make run-cc-tests'
 	@echo ' '
 	@echo 'To build client-server performance test programs and run performance test'
-	@echo ' make clean && CXX=g++ LD=g++ make client-server-perf-test'
+	@echo ' make clean && CC=gcc LD=g++ make client-server-perf-test'
 	@echo ' '
 	@echo 'Environment variables: '
 	@echo ' BUILD_MODE={release,debug}'

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,11 @@ help::
 	@echo ' make clean && CC=g++ CXX=g++ LD=g++ make all-cc-tests'
 	@echo ' make run-cc-tests'
 	@echo ' '
-	@echo 'To build client-server performance test programs and run performance test'
-	@echo ' make clean && CC=gcc LD=g++ make client-server-perf-test'
+	@echo 'To build client-server performance test programs and run performance test(s)'
+	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0     make client-server-perf-test  # Baseline'
+	@echo ' make clean && CC=gcc LD=g++                  make client-server-perf-test  # L3-logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1 make client-server-perf-test  # L3+LOC logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2 make client-server-perf-test  # L3+LOC-ELF logging'
 	@echo ' '
 	@echo 'Environment variables: '
 	@echo ' BUILD_MODE={release,debug}'
@@ -553,6 +556,8 @@ CLIENT_SERVER_PERF_TESTS_DIR   := $(USE_CASES)/client-server-msgs-perf
 # we will build standalone client and server binaries.
 CLIENT_SERVER_PERF_TESTS_SRCS   := $(wildcard $(CLIENT_SERVER_PERF_TESTS_DIR)/*.c)
 
+CLIENT_SERVER_PERF_TESTS_SRCS   += $(L3_UTILS_SRCS)
+
 # Build pair of sources for client-/server-main sources.
 CLIENT_SERVER_CLIENT_MAIN_SRC   := $(filter %_client.c, $(CLIENT_SERVER_PERF_TESTS_SRCS))
 CLIENT_SERVER_SERVER_MAIN_SRC   := $(filter %_server.c, $(CLIENT_SERVER_PERF_TESTS_SRCS))
@@ -613,6 +618,7 @@ $(CLIENT_SERVER_PROGRAM_GENSRC): | $(BINDIR)/$(USE_CASES)/.
 	@$(LOCGENPY) --gen-includes-dir  $(L3_INCDIR) --gen-source-dir $(dir $@) --src-root-dir $(dir $@) --loc-decoder-dir $(BINDIR)/$(USE_CASES) --verbose
 	@echo
 
+client-server-perf-test: INCLUDE += -I ./$(L3_UTILSDIR)
 client-server-perf-test: $(CLIENT_SERVER_PROGRAM_GENSRC) $(CLIENT_SERVER_PERF_TEST_BINS)
 
 # ##############################################################################

--- a/l3_dump.py
+++ b/l3_dump.py
@@ -156,11 +156,24 @@ String dump of section '.rodata':
     ... and so on.
     """
     # Run: llvm-readelf -p __cstring  ./build/release/bin/unit/l3_dump.py-test
+    # NOTE: For some tests, we were unable to hexdump the .rodata section and
+    # were running into this error:
+    #   File "/usr/lib/python3.10/subprocess.py", line 2059, in _communicate
+    #       stdout = self._translate_newlines(stdout,
+    #   File "/usr/lib/python3.10/subprocess.py", line 1031, in _translate_newlines
+    #       data = data.decode(encoding, errors)
+    #
+    # pylint: disable-next=line-too-long
+    #   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xea in position 1371: invalid continuation byte
+    #
+    # Hence, the errors='ignore' clause below.
+
     with subprocess.Popen([READELF_BIN, READELF_STRDUMP_ARG,
                            READELF_DATA_SECTION,
                            program_bin],
                           stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE, text=True) as rodata_hexdump:
+                          stderr=subprocess.PIPE, text=True,
+                          errors='ignore') as rodata_hexdump:
         _stdout, _stderr = rodata_hexdump.communicate()
 
     # pylint: disable-next=unused-variable

--- a/use-cases/client-server-msgs-perf/svmsg_file.h
+++ b/use-cases/client-server-msgs-perf/svmsg_file.h
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <time.h>
 #include "tlpi_hdr.h"
 
 #define SERVER_KEY 0x1aaaaaa1           /* Key for server's message queue */
@@ -72,4 +73,15 @@ typedef struct responseMsg {            /* Responses (server to client) */
 } responseMsg;
 
 #define RESP_MSG_SIZE sizeof(responseMsg)
+
+// Useful constants
+#define L3_MILLION      ((uint32_t) (1000 * 1000))
+#define L3_NS_IN_SEC    ((uint32_t) (1000 * L3_MILLION))
+
+// Convert timespec value to nanoseconds units.
+static uint64_t inline
+timespec_to_ns(struct timespec *ts)
+{
+    return ((ts->tv_sec * L3_NS_IN_SEC) + ts->tv_nsec);
+}
 

--- a/use-cases/client-server-msgs-perf/svmsg_file.h
+++ b/use-cases/client-server-msgs-perf/svmsg_file.h
@@ -11,6 +11,14 @@
 /* svmsg_file.h
 
    Header file for svmsg_file_server.c and svmsg_file_client.c.
+   The server and client communicate using System V message queues.
+
+   This version of the application has been extensively modified based
+   on an initial version downloaded from:
+   https://man7.org/tlpi/code/online/all_files_by_chapter.html
+
+   And extended for performance benchmarking of a very basic client-server
+   message-exchange program.
 */
 #include <sys/types.h>
 #include <sys/msg.h>
@@ -28,7 +36,7 @@
 #define MAX_CLIENTS 64
 
 /**
- * Types for request / response messages sent from server to client
+ * Message Types for request / response messages sent from server to client
  */
 typedef enum {
       REQ_MT_UNKNOWN    = 0
@@ -48,7 +56,6 @@ typedef enum {
     , RESP_MT_INCR  = REQ_MT_INCR
     , RESP_MT_DECR  = REQ_MT_DECR
     , RESP_MT_QUIT  = REQ_MT_QUIT
-
 
 } req_resp_type_t;
 
@@ -84,4 +91,3 @@ timespec_to_ns(struct timespec *ts)
 {
     return ((ts->tv_sec * L3_NS_IN_SEC) + ts->tv_nsec);
 }
-

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -47,17 +47,8 @@
 
 // Useful constants
 #define L3_100K         ((uint32_t) (100 * 1000))
-#define L3_MILLION      ((uint32_t) (10 * L3_100K))
-#define L3_NS_IN_SEC    ((uint32_t) (1000 * 1000 * 1000))
 
 static int clientId;
-
-// Convert timespec value to nanoseconds units.
-static uint64_t inline
-timespec_to_ns(struct timespec *ts)
-{
-    return ((ts->tv_sec * L3_NS_IN_SEC) + ts->tv_nsec);
-}
 
 static void
 removeQueue(void)

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -8,13 +8,31 @@
 * the file COPYING.gpl-v3 for details.                                    *
 \*************************************************************************/
 
-/* svmsg_file_server.c
+/* ****************************************************************************
+ * svmsg_file_server.c
+ * ****************************************************************************
 
    The server and client communicate using System V message queues.
 
    This version of the application has been extensively modified based
    on an initial version downloaded from:
    https://man7.org/tlpi/code/online/all_files_by_chapter.html
+
+Usage: ./svmsg_file_server --help
+       ./svmsg_file_server [ --clock-monotonic
+                            | --clock-realtime
+                            | --clock-process-cputime-id
+                            | --clock-thread-cputime-id ]
+
+   NOTE: On Linux, this program supports cmdline flags --clock-<something> to select
+         a different clock to "measure" time taken to implement the message.
+
+         The clock is hard-coded on Mac/OSX to CLOCK_THREAD_CPUTIME_ID:
+
+          a) This is the only clock with 1ns clock resolution on Mac.
+          b) Mac/OSX system call seems to not work well with `clock_id` int and
+             needs a mnemonic. So, parametrizing the call using `clock_id`
+             selected by a cmdline flag did not seem practical.
 
    The application is a very simple process:
     client -- counter --> server (incr/decr) -> respond new counter to client
@@ -43,24 +61,27 @@
 
    This program operates as a serialized server, processing all client requests
    serially.
+ * ****************************************************************************
 */
+#include <stdlib.h>
 #include <inttypes.h>
 #include <time.h>
 #include <assert.h>
+#include <getopt.h>     // For getopt_long()
 #include "svmsg_file.h"
 #include "l3.h"
+#include "size_str.h"
 
 /**
  * Global data structures to track client-specific information.
  */
 typedef struct client_info {
     int             clientId;
-    int             client_idx; // Into ActiveClients[] array, below
-    int64_t         client_ctr; // Current value of client's counter
-    uint64_t        cumu_thread_cpu_time_ns;
-                                // Cumulative thread-CPU time for operation.
-    uint64_t        num_ops;    // # of msg-op requests received
-    req_resp_type_t last_mtype; // Last requests->mtype
+    int             client_idx;     // Into ActiveClients[] array, below
+    int64_t         client_ctr;     // Current value of client's counter
+    uint64_t        cumu_time_ns;   // Cumulative time for operation.
+    uint64_t        num_ops;        // # of msg-op requests received
+    req_resp_type_t last_mtype;     // Last requests->mtype
 } Client_info;
 
 Client_info ActiveClients[MAX_CLIENTS];
@@ -82,6 +103,31 @@ Client_info ActiveClients[MAX_CLIENTS];
 static unsigned int   NumActiveClientsHWM = 0;
 static unsigned int   NumActiveClients    = 0;
 
+/**
+ * Simple argument parsing structure.
+ */
+struct option Long_options[] = {
+      { "help"                      , no_argument         , NULL, 'h'}
+    , { "clock-monotonic"           , no_argument         , NULL, 'm'}
+    , { "clock-process-cputime-id"  , no_argument         , NULL, 'p'}
+    , { "clock-realtime"            , no_argument         , NULL, 'r'}
+    , { "clock-thread-cputime-id"   , no_argument         , NULL, 't'}
+    , { NULL, 0, NULL, 0}           // End of options
+};
+
+const char * Options_str = ":hrmptd";
+
+// Function Prototypes
+
+int parse_arguments(const int argc, char *argv[], int *clock_id);
+void print_usage(const char *program, struct option options[]);
+void printSummaryStats(Client_info *clients, unsigned int num_clients,
+                       int clock_id);
+
+void svr_clock_getres(void);
+const char *clock_name(int clock_id);
+const char *time_metric_name(int clock_id);
+
 static void             /* SIGCHLD handler */
 grimReaper(int sig)
 {
@@ -94,47 +140,35 @@ grimReaper(int sig)
     errno = savedErrno;
 }
 
-// Find the resolution of the clock used in the program's timing measurement.
-void
-svr_clock_getres(void)
-{
-    struct timespec ts_real;
-    if (clock_getres(CLOCK_REALTIME, &ts_real)) {
-        errExit("clock_getres-ts_real");
-    }
-
-    struct timespec ts_monotonic;
-    if (clock_getres(CLOCK_MONOTONIC, &ts_monotonic)) {
-        errExit("clock_getres-ts_monotonic");
-    }
-
-    struct timespec ts_processCPU;
-    if (clock_getres(CLOCK_PROCESS_CPUTIME_ID, &ts_processCPU)) {
-        errExit("clock_getres-ts_processCPU");
-    }
-
-    struct timespec ts_threadCPU;
-    if (clock_getres(CLOCK_THREAD_CPUTIME_ID, &ts_threadCPU)) {
-        errExit("clock_getres-ts_threadCPU");
-    }
-    printf("Server clocks resolution"
-           ": CLOCK_REALTIME=%" PRIu64 " ns"
-           ", CLOCK_MONOTONIC=%" PRIu64 " ns"
-           ", CLOCK_PROCESS_CPUTIME_ID=%" PRIu64 " ns"
-           ", CLOCK_THREAD_CPUTIME_ID=%" PRIu64 " ns"
-           "\n",
-           timespec_to_ns(&ts_real),
-           timespec_to_ns(&ts_monotonic),
-           timespec_to_ns(&ts_processCPU),
-           timespec_to_ns(&ts_threadCPU));
-}
-
+/**
+ * ****************************************************************************
+ * main() - Server program.
+ * ****************************************************************************
+ */
 int
 main(int argc, char *argv[])
 {
     ssize_t msgLen;
     int     serverId;
     struct sigaction sa;
+
+    // On MacOSX, only the CLOCK_THREAD_CPUTIME_ID clock has a resolution of 1ns.
+    // On Linux, all clocks seem to have 1 ns resolution, so, default is to also
+    // use the same CLOCK_THREAD_CPUTIME_ID.
+    int clock_id;
+
+#if __APPLE__
+    printf("%s is currently not supported on Mac/OSX\n", argv[0]);
+    exit(EXIT_SUCCESS);
+#endif
+
+    clock_id = CLOCK_THREAD_CPUTIME_ID;
+
+    // Arg-parsing is only supported on Linux.
+    int rv = parse_arguments(argc, argv, &clock_id);
+    if (rv) {
+        errExit("Argument error.");
+    }
 
     svr_clock_getres();
 
@@ -175,8 +209,15 @@ main(int argc, char *argv[])
     const char *loc_scheme = "(no LOC)";
 #endif  // L3_LOC_ELF_ENCODING
 
-    printf("Server: Initiate L3-logging to log-file '%s'"
-           ", using %s encoding scheme.\n", logfile, loc_scheme);
+    printf("Start Server, using clock '%s'"
+           ": Initiate L3-logging to log-file '%s'"
+           ", using %s encoding scheme.\n",
+           logfile, loc_scheme, clock_name(clock_id));
+
+#else // L3_ENABLED
+
+    printf("Start Server, using clock ID=%d '%s': No logging.\n",
+           clock_id, clock_name(clock_id));
 
 #endif // L3_ENABLED
 
@@ -184,16 +225,8 @@ main(int argc, char *argv[])
     requestMsg req;
     responseMsg resp;
 
-    // On MacOSX, only the CLOCK_THREAD_CPUTIME_ID clock has a resolution of 1ns.
-    // On Linux, all clocks seem to have 1 ns resolution, so use real-time clock.
-    int one_ns_res_clock_id;
-#if __APPLE__
-    one_ns_res_clock_id = CLOCK_THREAD_CPUTIME_ID;
-#else
-    one_ns_res_clock_id = CLOCK_REALTIME;
-#endif  // __APPLE__
-
     for (;;) {
+
         msgLen = msgrcv(serverId, &req, REQ_MSG_SIZE, 0, 0);
         if (msgLen == -1) {
             if (errno == EINTR) {       /* Interrupted by SIGCHLD handler? */
@@ -233,47 +266,52 @@ main(int argc, char *argv[])
 
             NumActiveClients++;
             NumActiveClientsHWM++;
-            printf("Server: Client ID=%d joined. # active clients=%d (HWM=%d)\n",
-                   req.clientId, NumActiveClients, NumActiveClientsHWM);
+            printf("Server: Client ID=%d joined. Clock ID=%d, # active clients=%d (HWM=%d)\n",
+                   req.clientId, clock_id, NumActiveClients, NumActiveClientsHWM);
             break;
 
           case REQ_MT_INCR:
-            if (clock_gettime(one_ns_res_clock_id, &ts0)) {     // Timing begins
+            if (clock_gettime(clock_id, &ts0)) {    // Timing begins
                 errExit("clock_gettime-ts0");
             }
+
             clientp = &ActiveClients[req.client_idx];
             assert(clientp->clientId == req.clientId);
 
-            // Construct response message
-            resp.mtype = REQ_MT_INCR;
-            resp.clientId = req.clientId;   // For this client
+            resp.mtype = REQ_MT_INCR;               // Construct response message
+            resp.clientId = req.clientId;           // For this client
             resp.client_idx = req.client_idx;
 
-            // Implement and record increment.
-            clientp->last_mtype = REQ_MT_INCR;
-            resp.counter = ++clientp->client_ctr;
-            clientp->num_ops++;
+            clientp->last_mtype = REQ_MT_INCR;      // Prepare to increment
+            resp.counter = ++clientp->client_ctr;   // Do Increment
+            clientp->num_ops++;                     // Track # of operations
 
-            if (clock_gettime(one_ns_res_clock_id, &ts1)) {     // Timing ends
+            if (clock_gettime(clock_id, &ts1)) {    // Timing ends
                 errExit("clock_gettime-ts1");
             }
 
             nsec0 = timespec_to_ns(&ts0);
             nsec1 = timespec_to_ns(&ts1);
-            elapsed_ns = (nsec1 - nsec0);
-            clientp->cumu_thread_cpu_time_ns += elapsed_ns;
+            elapsed_ns = (nsec1 - nsec0);           // Elapsed-ns for this op
 
 #if L3_ENABLED
-            // Record time-consumed, clarifying semantic of elapsed time.
+            // Record time-consumed. (NOTE: See clarification below.)
             l3_log_simple("Server msg: Increment: ClientID=%d, "
-
-#if __APPLE__
-                          "Thread-CPU-"
-#else
-                          "Elapsed real-"
-#endif  // __APPLE__
-                          "time=%" PRIu64 " ns.", resp.clientId, elapsed_ns);
+                          "Thread-CPU-time=%" PRIu64 " ns.",
+                          resp.clientId, elapsed_ns);
 #endif // L3_ENABLED
+
+            // Reuse variable to reacquire current TS for accumulation.
+            // Cumulative time-consumed gives a read into impact of any
+            // logging call that might be done in diff micro-benchmarks.
+
+            if (clock_gettime(clock_id, &ts1)) {    // Cumulative timing ends
+                errExit("clock_gettime-ts1");
+            }
+            nsec1 = timespec_to_ns(&ts1);
+            elapsed_ns = (nsec1 - nsec0);
+            clientp->cumu_time_ns += elapsed_ns;    // Cumulative elapsed-ns
+
             break;
 
           case REQ_MT_EXIT:
@@ -282,17 +320,27 @@ main(int argc, char *argv[])
             // One client has informed that it has exited
             NumActiveClients--;
 
-#if __APPLE__
-            const char *time_msg = "Thread-CPU-time";
-#else
-            const char *time_msg = "Elapsed real-time";
-#endif  // __APPLE__
-            printf("Server: Client ID=%d exited. num_ops=%" PRIu64
-                   ", Avg. %s=%" PRIu64 " ns/msg, # active clients=%d\n",
+            // NOTE: If server is started using one of the --clock arguments,
+            // the metric's name logged in L3's log-line, above, will be
+            // misleading. It needs to be hard-coded to a literal string at
+            // compile-time. The metric's name given below is the right one
+            // corresponding to the active clock.
+            size_t throughput = (uint64_t)
+                        ((clientp->num_ops * 1.0 / clientp->cumu_time_ns)
+                                    * L3_NS_IN_SEC);
+
+            printf("Server: Client ID=%d exited. num_ops=%" PRIu64 " (%s)"
+                   ", cumu_time_ns=%" PRIu64
+                   " (clock_id=%d)"
+                   ", Avg. %s time=%" PRIu64 " ns/msg"
+                   ", throughput=%lu (%s) ops/sec"
+                   ", # active clients=%d\n",
                    req.clientId,
-                   clientp->num_ops,
-                   time_msg,
-                   (clientp->cumu_thread_cpu_time_ns / clientp->num_ops),
+                   clientp->num_ops, value_str(clientp->num_ops),
+                   clientp->cumu_time_ns,
+                   clock_id, time_metric_name(clock_id),
+                   (clientp->cumu_time_ns / clientp->num_ops),
+                   throughput, value_str(throughput),
                    NumActiveClients);
 
             if (NumActiveClients == 0) {
@@ -323,5 +371,190 @@ main(int argc, char *argv[])
     }
     printf("Server: # active clients=%d (HWM=%d). Exiting.\n",
            NumActiveClients, NumActiveClientsHWM);
+
+    printSummaryStats(ActiveClients, NumActiveClientsHWM, clock_id);
+
     exit(EXIT_SUCCESS);
+}
+
+/**
+ * Helper methods
+ */
+
+/**
+ * Simple argument parsing support.
+ */
+int
+parse_arguments(const int argc, char *argv[], int *clock_id)
+{
+    int option_index = 0;
+    int opt;
+
+    while ((opt = getopt_long(argc, argv, Options_str,  Long_options, &option_index))
+                != -1) {
+        switch (opt) {
+            case 'h':
+                print_usage((const char *) argv[0], Long_options);
+                exit(EXIT_SUCCESS);
+
+            case ':':
+                printf("%s: Option '%c' requires an argument\n",
+                       argv[0], optopt);
+                return EXIT_FAILURE;
+
+            case 'r':
+                *clock_id = CLOCK_REALTIME;
+                break;
+
+            case 'm':
+                *clock_id = CLOCK_MONOTONIC;
+                break;
+
+            case 'p':
+                *clock_id = CLOCK_PROCESS_CPUTIME_ID;
+                break;
+
+            case 't':
+                *clock_id = CLOCK_THREAD_CPUTIME_ID;
+                break;
+
+            case '?': // Invalid option or missing argument
+                printf("%s: Invalid option '%c' or missing argument\n",
+                       argv[0], opt);
+                return EXIT_FAILURE;
+
+            default:
+                // Handle error
+                return EXIT_FAILURE;
+        }
+    }
+    return 0;
+}
+
+void
+print_usage(const char *program_name, struct option options[])
+{
+    printf("Usage: %s [options] "
+           "{-p | --program-binary} <program-binary> [ <loc-IDs>+ ]\n",
+           program_name);
+    printf("Options:\n");
+
+    for (int i = 0; options[i].name != NULL; i++) {
+        if (options[i].val != 0) {
+            printf("  -%c, --%s", options[i].val, options[i].name);
+        } else {
+            printf("      --%s", options[i].name);
+        }
+
+        if (options[i].has_arg == required_argument) {
+            printf(" <%s>", options[i].name);
+        } else if (options[i].has_arg == optional_argument) {
+            printf(" [<%s>]", options[i].name);
+        }
+        printf("\n");
+    }
+}
+
+// Find the resolution of the clock used in the program's timing measurement.
+void
+svr_clock_getres(void)
+{
+    struct timespec ts_real;
+    if (clock_getres(CLOCK_REALTIME, &ts_real)) {
+        errExit("clock_getres-ts_real");
+    }
+
+    struct timespec ts_monotonic;
+    if (clock_getres(CLOCK_MONOTONIC, &ts_monotonic)) {
+        errExit("clock_getres-ts_monotonic");
+    }
+
+    struct timespec ts_processCPU;
+    if (clock_getres(CLOCK_PROCESS_CPUTIME_ID, &ts_processCPU)) {
+        errExit("clock_getres-ts_processCPU");
+    }
+
+    struct timespec ts_threadCPU;
+    if (clock_getres(CLOCK_THREAD_CPUTIME_ID, &ts_threadCPU)) {
+        errExit("clock_getres-ts_threadCPU");
+    }
+    printf("# Debug info:"
+           " Server clocks resolution"
+           ": CLOCK_REALTIME [id=%d] = %" PRIu64 " ns"
+           ", CLOCK_MONOTONIC [id=%d] = %" PRIu64 " ns"
+           ", CLOCK_PROCESS_CPUTIME_ID [id=%d] = %" PRIu64 " ns"
+           ", CLOCK_THREAD_CPUTIME_ID [id=%d] = %" PRIu64 " ns"
+           "\n\n",
+           CLOCK_REALTIME, timespec_to_ns(&ts_real),
+           CLOCK_MONOTONIC, timespec_to_ns(&ts_monotonic),
+           CLOCK_PROCESS_CPUTIME_ID, timespec_to_ns(&ts_processCPU),
+           CLOCK_THREAD_CPUTIME_ID, timespec_to_ns(&ts_threadCPU));
+}
+
+// Return hard-code string of clock-name given clock-ID
+// We need this and time_metric_name() as the clock_id mnemonics are
+// not sequential on Mac/OSX, which does not allow use of string lookup
+// tables. So, need to do some remapping.
+const char *
+clock_name(int clock_id)
+{
+    switch (clock_id) {
+      case CLOCK_REALTIME:
+        return "CLOCK_REALTIME";
+
+      case CLOCK_MONOTONIC:
+        return "CLOCK_MONOTONIC";
+
+      case CLOCK_PROCESS_CPUTIME_ID:
+        return "CLOCK_PROCESS_CPUTIME_ID";
+
+      case CLOCK_THREAD_CPUTIME_ID:
+        return "CLOCK_THREAD_CPUTIME_ID";
+    }
+    return "CLOCK_UNKNOWN";
+}
+
+// Return hard-code string of semantic of time tracked by given clock-ID
+const char *
+time_metric_name(int clock_id)
+{
+    switch (clock_id) {
+      case CLOCK_REALTIME:
+        return "Elapsed real";
+
+      case CLOCK_MONOTONIC:
+        return "Monotonic";
+
+      case CLOCK_PROCESS_CPUTIME_ID:
+        return "Process-CPU";
+
+      case CLOCK_THREAD_CPUTIME_ID:
+        return "Thread-CPU";
+    }
+    return "unknown";
+}
+
+/**
+ * printSummaryStats() - Aggregate metrics and print summary across all clients.
+ */
+void
+printSummaryStats(Client_info *clients, unsigned int num_clients,
+                  int clock_id)
+{
+    size_t  num_ops = 0;
+    size_t  cumu_time_ns = 0;
+
+    for (int cctr = 0 ; cctr < num_clients; cctr++) {
+        num_ops += clients[cctr].num_ops;
+        cumu_time_ns += clients[cctr].cumu_time_ns;
+    }
+    size_t throughput = (uint64_t) ((num_ops * 1.0 / cumu_time_ns)
+                                        * L3_NS_IN_SEC);
+    printf("For %u clients, num_ops=%lu (%s) ops"
+           ", Avg. %s time=%lu ns/msg"
+           ", throughput=%lu (%s) ops/sec"
+           "\n",
+           num_clients, num_ops, value_str(num_ops),
+           time_metric_name(clock_id), (cumu_time_ns / num_ops),
+           throughput, value_str(throughput));
 }


### PR DESCRIPTION
## Objective

The objective of this change is to demonstrate some realistic usages of L3-logging, which is currently done on the server-side of a simple client/server msg-send-recv application.

Rather than logging a plain 'Server msg' info, with some client details, we now also track the real-time / thread-CPU-time consumed on the server-side, for each client-op request. We only measure the block of code after msgrecv(), so don't track other scaffolding overheads.

The L3-logging call is now changed to also log this metric, which is a more natural use-case for this kind of logging API.

@gregthelaw - You can start reviewing this multi-part PR. I have reworked the implementation based on what we discussed yesterday and to prepare this change-set to be more inline with the `l3-perf-bm` proposal aired out in this discussion #43 . 

------

## Implementation

This PR has 3 commits in this order:

1. l3_dump.py: Add errors='ignore' clause to parse_rodata_string_offsets(): Fix applied to dump Python script to deal with some case where Unicode chars are generated in one of the test workloads.

2. [Perf] Track time-consumed for processing each request on server-side.

3. [Perf] Improve usability and metrics of client-server perf testbed: Tracks throughput metrics.

With the last 2 changes, following is the summary output w/o L3-logging (baseline) and with L3-logging:

```
agurajada-Linux-Vm:[3152] $ egrep -E 'Start Server|clients, num_ops' ~/tmp/perf.1Mil.out

Start Server, using clock ID=3 'CLOCK_THREAD_CPUTIME_ID': No logging.
For 5 clients, num_ops=5000000 (5 Million) ops, Avg. Thread-CPU time=542 ns/msg, throughput=1843753 (~1.84 Million) ops/sec

Start Server, using clock '/tmp/l3.c-server-test.dat': Initiate L3-logging to log-file '(no LOC)', using CLOCK_THREAD_CPUTIME_ID encoding scheme.
For 5 clients, num_ops=5000000 (5 Million) ops, Avg. Thread-CPU time=587 ns/msg, throughput=1703080 (~1.70 Million) ops/sec
```

-------

This commit implements on the server-side:

- Thread-specific CPU-time consumed for processing each client request received.
- Cumulative CPU-time and # requests is also tracked for each client.
- L3-log is changed to log the CPU-time consumed to implement each request.
- When client exits, the stats of # of requests received and avg. CPU-time/request is printed.

Measurement clock chosen:

 - Linux: Use CLOCK_REALTIME as it seems to have a resolution of 1 ns.
 - Mac: We use CLOCK_THREAD_CPUTIME_ID to measure the time taken to implement
   each request as its resolution is 1ns. All other clocks have a resolution
   of 1000 ns (as seen on my Mac).

With this enhancement, we should see these enhanced messages upon running the
L3-dump after running the exercise:

- Refactor `common timespec_to_ns()` into `svmsg_file.h` as it's now shared by client / server files.

We should see these enhanced messages (on a Mac/OSX):

- On server-side:
```
Server: Client ID=5701633 exited. num_ops=1000, Avg. thread-CPU-ns=351 ns/msg, # active clients=2
Server: Client ID=5570563 exited. num_ops=1000, Avg. thread-CPU-ns=351 ns/msg, # active clients=1
Client: ID=5570564 Performed 1000 message send/receive operations, ctr=1000, 35803 ns/msg (avg) Exiting.
Server: Client ID=5570564 exited. num_ops=1000, Avg. thread-CPU-ns=352 ns/msg, # active clients=0
Server: # active clients=0 (HWM=5). Exiting.
```

- From L3-dump utility:
```
tid=259 'Server msg: Increment: ClientID=5570563, Thread CPU-time=326 ns.' tid=259 'Server msg: Increment: ClientID=5570564, Thread CPU-time=361 ns.' tid=259 'Server msg: Increment: ClientID=5570564, Thread CPU-time=446 ns.' tid=259 'Server msg: Increment: ClientID=5570564, Thread CPU-time=453 ns.' Unpacked nentries=5000 log-entries.
```


---
With L3_LOC enabled L3-log'ged messages are like follows:

---
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5636100, Thread CPU-time=333 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5636098, Thread CPU-time=331 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5767169, Thread CPU-time=334 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5636100, Thread CPU-time=329 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5767169, Thread CPU-time=446 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5636100, Thread CPU-time=340 ns.'
tid=259 client-server-msgs-perf/svmsg_file_server.c:258  'Server msg: Increment: ClientID=5767169, Thread CPU-time=425 ns.'
Unpacked nentries=5000 log-entries.

--
Note the `Thread CPU-time=340 ns.` fragment, which is new with this change.