### PR TITLE
[Util] Add size_to_str() and value_to_str() unit-conversion interfaces

### DIFF
--- a/tests/unit/size_str-test.c
+++ b/tests/unit/size_str-test.c
@@ -1,0 +1,118 @@
+/**
+ * *****************************************************************************
+ * unit/size_str-test.c
+ *
+ * Simple unit-test to exercise the size-formatting interfaces in size_str.c
+ *
+ * These interfaces have already been unit-tested in the upstream repo
+ * sources. All we do here is to exercise the conversion APIs with a set of
+ * unit-test cases, expanded to also cover the value_to_str() and value_fmtstr()
+ * interfaces, just to make sure that things run, and don't fall-over.
+ *
+ * Author: Aditya P. Gurajada
+ * Copyright (c) 2024
+ * *****************************************************************************
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdbool.h>
+#include <assert.h>
+#include "size_str.h"
+
+#define ARRAY_SIZE(arr) (int) (sizeof(arr) / sizeof(*arr))
+
+_Bool test_streqn(const char *str, const char *expstr);
+
+int
+main(const int argc, const char **argv)
+{
+   typedef struct size_to_expstr {
+      size_t size;
+      char  *expstr_b;  // size treated as bytes converted to string.
+      char  *expstr_v;  // size treated as value converted to string.
+   } size_to_expstr;
+
+   // Exercise the string formatter with typical data values.
+   size_to_expstr size_to_str_cases[] =
+   {
+        // size                                                     bytes-as-str            value-as-str
+          { 129                                                 , "129 bytes"           , ""                }   //  0
+
+        , { SZ_KiB                                              , "1 KiB"               , "~1.02 K"         }   //  1
+        , { VAL_OneK                                            , "1000 bytes"          , "1 K"             }   //  2
+        , { SZ_KiB + 128                                        , "~1.12 KiB"           , "~1.15 K"         }   //  3
+        , { SZ_KiB + ((25 * SZ_KiB) / 100)                      , "~1.25 KiB"           , "~1.28 K"         }   //  4
+        , { ( 2 * SZ_KiB )                                      , "2 KiB"               , "~2.04 K"         }   //  5
+        , { ( 2 * VAL_OneK )                                    , "~1.95 KiB"           , "2 K"             }   //  6
+
+        , { VAL_Million                                         , "~976.56 KiB"         , "1 Million"       }   //  7
+        , { SZ_MiB                                              , "1 MiB"               , "~1.04 Million"   }   //  8
+        , { SZ_MiB + 128                                        , "~1.00 MiB"           , "~1.04 Million"   }   //  9
+        , { SZ_MiB + ((5 * SZ_MiB) / 10)                        , "~1.50 MiB"           , "~1.57 Million"   }   // 10
+        , { ( VAL_Million + VAL_OneK )                          , "~977.53 KiB"         , "~1.00 Million"   }   // 11
+
+        , { ( VAL_Billion - VAL_Million - ( 2 * VAL_OneK ) )    , "~952.71 MiB"         , "~998.99 Million" }   // 12
+        , { VAL_Billion                                         , "~953.67 MiB"         , "1 Billion"       }   // 13
+        , { ( VAL_Billion + VAL_Million + ( 3 * VAL_OneK ) )    , "~954.63 MiB"         , "~1.00 Billion"   }   // 14
+        , { SZ_GiB                                              , "1 GiB"               , "~1.07 Billion"   }   // 15
+        , { SZ_GiB + 128                                        , "~1.00 GiB"           , "~1.07 Billion"   }   // 16
+        , { SZ_GiB + ((75 * SZ_GiB) / 100)                      , "~1.75 GiB"           , "~1.87 Billion"   }   // 17
+        , { (3 * SZ_GiB) + ((5 * SZ_GiB) / 10)                  , "~3.50 GiB"           , "~3.75 Billion"   }   // 18
+
+        , { VAL_Trillion                                        , "~931.32 GiB"         , "1 Trillion"      }   // 19
+        , { SZ_TiB                                              , "1 TiB"               , "~1.09 Trillion"  }   // 20
+        , { SZ_TiB + 128                                        , "~1.00 TiB"           , "~1.09 Trillion"  }   // 21
+        , { (2 * SZ_TiB) + ((25 * SZ_TiB) / 100)                , "~2.25 TiB"           , "~2.47 Trillion"  }   // 22
+
+        // Specific data-values that tripped bugs in formatting output string
+        , { 2222981120                                          , "~2.07 GiB"           , "~2.22 Billion"   }   // 23
+        , { SZ_KiB + 28                                         , "~1.02 KiB"           , "~1.05 K"         }   // 24
+        , { SZ_MiB + (98 * SZ_KiB)                              , "~1.09 MiB"           , "~1.14 Million"   }   // 25
+        , { SZ_GiB + (555 * SZ_MiB)                             , "~1.54 GiB"           , "~1.65 Billion"   }   // 26
+   };
+
+   char size_str[SIZE_TO_STR_LEN];
+   char *outstr = NULL;
+   const char *expstr_b;
+   const char *expstr_v;
+
+   for (int ictr = 0; ictr < ARRAY_SIZE(size_to_str_cases); ictr++) {
+       size_t value = size_to_str_cases[ictr].size;
+       printf(" [%2d] Size  = %lu (%s)"
+              " "
+              "  Value = %lu (%s)\n",
+              ictr,
+              value, size_str(value),
+              value, value_fmtstr("%s", value));
+
+        expstr_b = size_to_str_cases[ictr].expstr_b;
+        expstr_v = size_to_str_cases[ictr].expstr_v;
+
+        outstr = size_to_str(size_str, sizeof(size_str), value);
+        assert(test_streqn(outstr, expstr_b));
+
+        outstr = value_to_str(size_str, sizeof(size_str), value);
+        assert(test_streqn(outstr, expstr_v));
+   }
+}
+
+// Simple string comparison method. Print diagnostics upon failure.
+_Bool
+test_streqn(const char *str, const char *expstr)
+{
+    _Bool rv = true;
+    size_t str_len = strlen(str);
+    if (str_len != strlen(expstr)) {
+        rv = false;
+    } else if (strncmp(str, expstr, str_len) != 0) {
+        rv = false;
+    }
+    if (!rv) {
+        printf("String '%s' does not match expected string '%s'\n",
+               str, expstr);
+
+    }
+    return rv;
+}

--- a/use-cases/utils/size_str.c
+++ b/use-cases/utils/size_str.c
@@ -1,0 +1,152 @@
+/**
+ * *****************************************************************************
+ * utils/size_str.c
+ *
+ * Format a size / number-value with unit-specifiers, in an output buffer.
+ *
+ * - Extracted the implementation of size_to_str() and associated caller-macros,
+ *   as standalone utility sources from the original implementation done
+ *   by the author in the SplinterDB project.
+ *
+ * - Expanded interface to also convert number-value(s) to a string with unit-
+ *   specifiers.
+ *
+ * Ref: https://github.com/vmware/splinterdb
+ *
+ * Author: Aditya P. Gurajada
+ * Copyright (c) 2024
+ * *****************************************************************************
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+#include "size_str.h"
+
+/*
+ * *****************************************************************************
+ * Format a size value with unit-specifiers, in an output buffer.
+ * Returns 'outbuf', as ptr to size-value snprintf()'ed as a string.
+ * *****************************************************************************
+ */
+char *
+size_to_str(char *outbuf, size_t outbuflen, size_t size)
+{
+   assert(outbuflen >= SIZE_TO_STR_LEN);
+   size_t unit_val  = 0;
+   size_t frac_val  = 0;
+   int is_approx = false;
+
+   char *units = NULL;
+   if (size >= SZ_TiB) {
+      unit_val  = SZ_B_TO_TiB(size);
+      frac_val  = SZ_B_TO_TiB_FRACT(size);
+      is_approx = (size > SZ_TiB_TO_B(unit_val));
+      units     = "TiB";
+
+   } else if (size >= SZ_GiB) {
+      unit_val  = SZ_B_TO_GiB(size);
+      frac_val  = SZ_B_TO_GiB_FRACT(size);
+      is_approx = (size > SZ_GiB_TO_B(unit_val));
+      units     = "GiB";
+
+   } else if (size >= SZ_MiB) {
+      unit_val  = SZ_B_TO_MiB(size);
+      frac_val  = SZ_B_TO_MiB_FRACT(size);
+      is_approx = (size > SZ_MiB_TO_B(unit_val));
+      units     = "MiB";
+
+   } else if (size >= SZ_KiB) {
+      unit_val  = SZ_B_TO_KiB(size);
+      frac_val  = SZ_B_TO_KiB_FRACT(size);
+      is_approx = (size > SZ_KiB_TO_B(unit_val));
+      units     = "KiB";
+   } else {
+      unit_val = size;
+      units    = "bytes";
+   }
+
+   if (frac_val || is_approx) {
+      snprintf(outbuf, outbuflen, "~%ld.%02ld %s", unit_val, frac_val, units);
+   } else {
+      snprintf(outbuf, outbuflen, "%ld %s", unit_val, units);
+   }
+   return outbuf;
+}
+
+/*
+ * Sibling of size_to_str(), but uses user-provided print format specifier.
+ * 'fmtstr' is expected to have just one '%s', and whatever other text user
+ * wishes to print with the output string.
+ */
+char *
+size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size)
+{
+   snprintf(outbuf, outbuflen, fmtstr, size_str(size));
+   return outbuf;
+}
+
+/*
+ * *****************************************************************************
+ * Format a number value with unit-specifiers, in an output buffer.
+ * Returns 'outbuf', as ptr to number-value snprintf()'ed as a string.
+ * *****************************************************************************
+ */
+char *
+value_to_str(char *outbuf, size_t outbuflen, size_t value)
+{
+   assert(outbuflen >= SIZE_TO_STR_LEN);
+   size_t unit_val  = 0;
+   size_t frac_val  = 0;
+   int is_approx = false;
+
+   char *units = NULL;
+   if (value >= VAL_Trillion) {
+      unit_val  = VAL_N_TO_Trillion(value);
+      frac_val  = VAL_N_TO_Trillion_FRACT(value);
+      is_approx = (value > VAL_Trillion_TO_N(unit_val));
+      units     = "Trillion";
+
+   } else if (value >= VAL_Billion) {
+      unit_val  = VAL_N_TO_Billion(value);
+      frac_val  = VAL_N_TO_Billion_FRACT(value);
+      is_approx = (value > VAL_Billion_TO_N(unit_val));
+      units     = "Billion";
+
+   } else if (value >= VAL_Million) {
+      unit_val  = VAL_N_TO_Million(value);
+      frac_val  = VAL_N_TO_Million_FRACT(value);
+      is_approx = (value > VAL_Million_TO_N(unit_val));
+      units     = "Million";
+
+   } else if (value >= VAL_OneK) {
+      unit_val  = VAL_N_TO_K(value);
+      frac_val  = VAL_N_TO_K_FRACT(value);
+      is_approx = (value > VAL_K_TO_N(unit_val));
+      units     = "K";
+   } else {
+      unit_val = value;
+   }
+
+   if (frac_val || is_approx) {
+      snprintf(outbuf, outbuflen, "~%ld.%02ld %s", unit_val, frac_val, units);
+   } else if (units) {
+      snprintf(outbuf, outbuflen, "%ld %s", unit_val, units);
+   } else {
+       // If value is less than 1K, no need to further output 'value>' in buffer.
+       *outbuf = '\0';
+   }
+   return outbuf;
+}
+
+/*
+ * Sibling of value_to_str(), but uses user-provided print format specifier.
+ * 'fmtstr' is expected to have just one '%s', and whatever other text user
+ * wishes to print with the output string.
+ */
+char *
+value_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t value)
+{
+   snprintf(outbuf, outbuflen, fmtstr, value_str(value));
+   return outbuf;
+}

--- a/use-cases/utils/size_str.h
+++ b/use-cases/utils/size_str.h
@@ -1,0 +1,145 @@
+/**
+ * *****************************************************************************
+ * utils/size_str.h
+ *
+ * Format a size value with unit-specifiers, in an output buffer.
+ *
+ * Extracted as standalone utility sources from original implementation done by
+ * the author in the SplinterDB project.
+ * Ref: https://github.com/vmware/splinterdb
+ *
+ * Author: Aditya P. Gurajada
+ * Copyright (c) 2024
+ * *****************************************************************************
+ */
+#pragma once
+
+// Data unit constants
+#define SZ_KiB (1024UL)
+#define SZ_MiB (SZ_KiB * 1024)
+#define SZ_GiB (SZ_MiB * 1024)
+#define SZ_TiB (SZ_GiB * 1024)
+
+// Convert 'x' in unit-specifiers to bytes
+#define SZ_KiB_TO_B(x) ((x) * SZ_KiB)
+#define SZ_MiB_TO_B(x) ((x) * SZ_MiB)
+#define SZ_GiB_TO_B(x) ((x) * SZ_GiB)
+#define SZ_TiB_TO_B(x) ((x) * SZ_TiB)
+
+// Convert 'x' in bytes to 'int'-value with unit-specifiers
+#define SZ_B_TO_KiB(x) ((x) / SZ_KiB)
+#define SZ_B_TO_MiB(x) ((x) / SZ_MiB)
+#define SZ_B_TO_GiB(x) ((x) / SZ_GiB)
+#define SZ_B_TO_TiB(x) ((x) / SZ_TiB)
+
+// For x bytes, returns as int the fractional portion modulo a unit-specifier
+#define SZ_B_TO_KiB_FRACT(x) ((100 * ((x) % SZ_KiB)) / SZ_KiB)
+#define SZ_B_TO_MiB_FRACT(x) ((100 * ((x) % SZ_MiB)) / SZ_MiB)
+#define SZ_B_TO_GiB_FRACT(x) ((100 * ((x) % SZ_GiB)) / SZ_GiB)
+#define SZ_B_TO_TiB_FRACT(x) ((100 * ((x) % SZ_TiB)) / SZ_TiB)
+
+// Value unit constants
+#define VAL_OneK        (1000UL)  // Use 'OneK' for convenience; it's actually 1000
+#define VAL_Million     (1000 * VAL_OneK)
+#define VAL_Billion     (1000 * VAL_Million)
+#define VAL_Trillion    (1000 * VAL_Billion)
+
+// Convert 'x' in unit-specifiers to value as a number, N
+#define VAL_K_TO_N(x)           ((x) * VAL_OneK)
+#define VAL_Million_TO_N(x)     ((x) * VAL_Million)
+#define VAL_Billion_TO_N(x)     ((x) * VAL_Billion)
+#define VAL_Trillion_TO_N(x)    ((x) * VAL_Trillion)
+
+// Convert 'x' as a number-value to 'int'-value with unit-specifiers
+#define VAL_N_TO_K(x)           ((x) / VAL_OneK)
+#define VAL_N_TO_Million(x)     ((x) / VAL_Million)
+#define VAL_N_TO_Billion(x)     ((x) / VAL_Billion)
+#define VAL_N_TO_Trillion(x)    ((x) / VAL_Trillion)
+
+// For x as a number-value, returns as int the fractional portion modulo
+// a unit-specifier
+#define VAL_N_TO_K_FRACT(x)         ((100 * ((x) % VAL_OneK))     / VAL_OneK)
+#define VAL_N_TO_Million_FRACT(x)   ((100 * ((x) % VAL_Million))  / VAL_Million)
+#define VAL_N_TO_Billion_FRACT(x)   ((100 * ((x) % VAL_Billion))  / VAL_Billion)
+#define VAL_N_TO_Trillion_FRACT(x)  ((100 * ((x) % VAL_Trillion)) / VAL_Trillion)
+
+// ----------------------------------------------------------------------
+// Format a size value with unit-specifiers, in an output buffer.
+// ----------------------------------------------------------------------
+
+char *
+size_to_str(char *outbuf, size_t outbuflen, size_t size);
+
+char *
+size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
+
+// Length of output buffer to snprintf()-into size as string w/ unit specifier
+#define SIZE_TO_STR_LEN 20
+
+/*
+ * ----------------------------------------------------------------------
+ * Convenience caller macros to convert 'sz' bytes to return a string,
+ * formatting the input size as human-readable value with unit-specifiers.
+ * ----------------------------------------------------------------------
+ */
+// char *size_str(size_t sz)
+#define size_str(sz)                                                           \
+   (({                                                                         \
+       struct {                                                                \
+          char buffer[SIZE_TO_STR_LEN];                                        \
+       } onstack_chartmp;                                                      \
+       size_to_str(                                                            \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), sz);         \
+       onstack_chartmp;                                                        \
+    }).buffer)
+
+// char *size_fmtstr(const char *fmtstr, size_t sz)
+#define size_fmtstr(fmtstr, sz)                                                \
+   (({                                                                         \
+       struct {                                                                \
+          char buffer[SIZE_TO_STR_LEN];                                        \
+       } onstack_chartmp;                                                      \
+       size_to_fmtstr(                                                         \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), fmtstr, sz); \
+       onstack_chartmp;                                                        \
+    }).buffer)
+
+
+// ----------------------------------------------------------------------
+// Format a number-value with unit-specifiers, in an output buffer.
+// ----------------------------------------------------------------------
+
+char *
+value_to_str(char *outbuf, size_t outbuflen, size_t size);
+
+char *
+value_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
+
+
+/*
+ * ----------------------------------------------------------------------
+ * Convenience caller macros to convert 'val' number-value to return a string,
+ * formatting the input size as human-readable value with unit-specifiers.
+ * ----------------------------------------------------------------------
+ */
+// char *value_str(size_t val)
+#define value_str(val)                                                          \
+   (({                                                                          \
+       struct {                                                                 \
+          char buffer[SIZE_TO_STR_LEN];                                         \
+       } onstack_chartmp;                                                       \
+       value_to_str(                                                            \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), val);         \
+       onstack_chartmp;                                                         \
+    }).buffer)
+
+// char *value_fmtstr(const char *fmtstr, size_t val)
+#define value_fmtstr(fmtstr, val)                                               \
+   (({                                                                          \
+       struct {                                                                 \
+          char buffer[SIZE_TO_STR_LEN];                                         \
+       } onstack_chartmp;                                                       \
+       value_to_fmtstr(                                                         \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), fmtstr, val); \
+       onstack_chartmp;                                                         \
+    }).buffer)


### PR DESCRIPTION
This commit adds following size-/value to string with unit-specifier interfaces.

- Convert 'size' value (e.g., memory, space) to a string: 
```
char * size_to_str(char *outbuf, size_t outbuflen, size_t size);
char * size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
```

- Convert number-value value (e.g. # of requests) to a string:
```
char * value_to_str(char *outbuf, size_t outbuflen, size_t size);
char * value_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
```
The size_to_str() implementation is extracted, and made stand-alone, out of the implementation done in the [SplinterDB repo](https://github.com/vmware/splinterdb). 

Further extended to add the `value_to_str()` interfaces.

- Add unit-test tests/unit/size_str-test.c
- Add Makefile rules to build and run unit-test.
- Fixes to get new code and tests working on Mac/OSX.

### Sample outputs:

  - Size  = 2048 (2 KiB)            Value = 2048 (~2.04 K)
  - Size  = 1000000 (~976.56 KiB)   Value = 1000000 (1 Million)
  - Size  = 1073741952 (~1.00 GiB)  Value = 1073741952 (~1.07 Billion)
  - Size  = 1099511627776 (1 TiB)   Value = 1099511627776 (~1.09 Trillion)


### Note to the reviewer:

@gregthelaw -- I am assigning a review to you, just so you see this change-set coming-in.

These are utility methods outside core L3 sources and I need these for improving the info-msgs from the performance test exerciser. Hence, I plan to check these in. The comments should be self-explanatory. And this code has been implemented and tested elsewhere, so I am comfortable about its correctness.

If you have any suggestions to improve this helper method, happy to take that up in a later change.