### PR TITLE
[L3] Rework logging APIs to invoke printf() for fmt-spec validation

### DIFF
--- a/include/l3.h
+++ b/include/l3.h
@@ -55,14 +55,57 @@ int l3_init(const char *path);
 
 /**
  * \brief Caller-macro to invoke L3 simple logging.
+ *
+ * Macro to synthesize LOC-encoding value, if needed, under conditional
+ * compilation flags. DEBUG-version of macros are provided to cross-check
+ * that the supplied format string in `msg` are consistent with the
+ * arguments' type.
  */
-#ifdef L3_LOC_ENABLED
-#define l3_log_simple(msg, arg1, arg2)                          \
-        l3__log_simple(__LOC__, (msg), (arg1), (arg2))
-#else   // L3_LOC_ENABLED
-#define l3_log_simple(msg, arg1, arg2)                          \
-        l3__log_simple(L3_ARG_UNUSED, (msg), (arg1), (arg2))
-#endif  //
+#if defined(DEBUG)
+
+  #ifdef L3_LOC_ENABLED
+
+    #define l3_log_simple(msg, arg1, arg2)                              \
+            if (1) {                                                    \
+                l3__log_simple((msg),                                   \
+                               (uint64_t) (arg1), (uint64_t) (arg2),    \
+                                 __LOC__);                              \
+            } else if (0) {                                             \
+                printf((msg), (arg1), (arg2));                          \
+            } else
+
+   #else   // L3_LOC_ENABLED
+
+    #define l3_log_simple(msg, arg1, arg2)                              \
+            if (1) {                                                    \
+                l3__log_simple((msg),                                   \
+                               (uint64_t) (arg1), (uint64_t) (arg2),    \
+                               L3_ARG_UNUSED);                          \
+            } else if (0) {                                             \
+                printf((msg), (arg1), (arg2));                          \
+            } else
+
+  #endif  // L3_LOC_ENABLED
+
+#else   // defined(DEBUG)
+
+  #ifdef L3_LOC_ENABLED
+
+    #define l3_log_simple(msg, arg1, arg2)                          \
+            l3__log_simple((msg),                                   \
+                           (uint64_t) (arg1), (uint64_t) (arg2),    \
+                           __LOC__)
+
+  #else   // L3_LOC_ENABLED
+
+    #define l3_log_simple(msg, arg1, arg2)                          \
+            l3__log_simple((msg),                                   \
+                           (uint64_t) (arg1), (uint64_t) (arg2),    \
+                           L3_ARG_UNUSED)
+
+  #endif  // L3_LOC_ENABLED
+
+#endif  // defined(DEBUG)
 
 /**
  * \brief Log a literal string and two arguments.
@@ -81,11 +124,11 @@ extern "C" {
 #endif
 
 #ifdef L3_LOC_ENABLED
-void l3__log_simple(const loc_t loc, const char *msg,
-                    const uint64_t arg1, const uint64_t arg2);
+void l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
+                    const loc_t loc);
 #else
-void l3__log_simple(const uint32_t loc, const char *msg,
-                    const uint64_t arg1, const uint64_t arg2);
+void l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
+                    const uint32_t loc);
 #endif  // L3_LOC_ENABLED
 
 #ifdef __cplusplus
@@ -101,12 +144,44 @@ void l3__log_simple(const uint32_t loc, const char *msg,
 
 #else   // __APPLE__
 
-#ifdef L3_LOC_ENABLED
+#if defined(DEBUG)
 
-#define l3_log_fast(msg, arg1, arg2) l3__log_fast(__LOC__, (msg), (arg1), (arg2))
-#else   // L3_LOC_ENABLED
-#define l3_log_fast(msg, arg1, arg2) l3__log_fast(L3_ARG_UNUSED, (msg), (arg1), (arg2))
-#endif  // L3_LOC_ENABLED
+  #ifdef L3_LOC_ENABLED
+
+    #define l3_log_fast(msg, arg1, arg2)                                    \
+            if (1) {                                                        \
+                l3__log_fast(__LOC__,                                       \
+                             (msg), (uint64_t) (arg1), (uint64_t) (arg2));  \
+            } else if (0) {                                                 \
+                printf((msg), (arg1), (arg2));                              \
+            } else
+
+  #else   // L3_LOC_ENABLED
+
+    #define l3_log_fast(msg, arg1, arg2)                                    \
+            if (1) {                                                        \
+                l3__log_fast(L3_ARG_UNUSED,                                 \
+                             (msg), (uint64_t) (arg1), (uint64_t) (arg2));  \
+            } else if (0) {                                                 \
+                printf((msg), (arg1), (arg2));                              \
+            } else
+
+  #endif  // L3_LOC_ENABLED
+
+#else   // DEBUG
+
+  #ifdef L3_LOC_ENABLED
+    #define l3_log_fast(msg, arg1, arg2)                            \
+            l3__log_fast(__LOC__, (msg),                            \
+                         (uint64_t) (arg1), (uint64_t) (arg2))
+  #else   // L3_LOC_ENABLED
+    #define l3_log_fast(msg, arg1, arg2)                            \
+            l3__log_fast(L3_ARG_UNUSED, (msg),                      \
+                         (uint64_t) (arg1), (uint64_t) (arg2))
+  #endif  // L3_LOC_ENABLED
+
+#endif  // DEBUG
+
 
 #endif  // __APPLE__
 

--- a/src/l3.c
+++ b/src/l3.c
@@ -230,11 +230,22 @@ l3_mytid(void)
 }
 
 // ****************************************************************************
+
+/**
+ * l3__log_simple() - 'C' interface to "slow" L3-logging.
+ *
+ * As 'loc' is an argument synthesized by the caller-macro, under conditional
+ * compilation, keep it as the last argument. This makes it possible to define
+ * DEBUG version of the caller-macro using printf(), for argument v/s print-
+ * format specifiers in 'msg'.
+ */
 void
 #ifdef L3_LOC_ENABLED
-l3__log_simple(loc_t loc, const char *msg, const uint64_t arg1, const uint64_t arg2)
+l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
+               loc_t loc)
 #else
-l3__log_simple(uint32_t loc, const char *msg, const uint64_t arg1, const uint64_t arg2)
+l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
+               uint32_t loc)
 #endif
 {
     int idx = __sync_fetch_and_add(&l3_log->idx, 1) % L3_MAX_SLOTS;

--- a/tests/unit/l3_dump.py-test.c
+++ b/tests/unit/l3_dump.py-test.c
@@ -48,8 +48,10 @@ void test_l3_slow_log(void)
     }
     l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
     l3_log_simple("Simple-log-msg-Args(arg3=%d, arg4=%d)", 3, 4);
-    l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
-    l3_log_simple("Invalid buffer handle (addr=0x%x), lockrec=0x%p", 0xbeefabcd, 0);
+
+    char *bp = (char *) 0xdeadbabe;
+    l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", bp, 1024);
+    l3_log_simple("Invalid buffer handle (addr=0x%x), lockrec=0x%p", 0xbeefabcd, NULL);
 
     printf("Generated slow log-entries to log-file: %s\n", log);
 }
@@ -64,8 +66,10 @@ void test_l3_fast_log(void)
     l3_log_fast("Fast-log-msg: Args(arg1=%d, arg2=%d)", 1, 2);
     l3_log_fast("Fast-log-msg: Args(arg3=%d, arg4=%d)", 3, 4);
     l3_log_fast("Fast-log-msg: Args(arg1=%d, arg2=%d)", 10, 20);
-    l3_log_fast("Fast-log-msg: Potential memory overwrite (addr=0x%x, size=%lu)", 0xdeadbabe, 1024);
-    l3_log_fast("Fast-log-msg: Invalid buffer handle (addr=0x%p), unused=%lu", 0xbeefabcd, 0);
+    l3_log_fast("Fast-log-msg: Potential memory overwrite (addr=0x%x, size=%d)", 0xdeadbabe, 1024);
+
+    void *bp = (void *) 0xbeefabcd;
+    l3_log_fast("Fast-log-msg: Invalid buffer handle (addr=0x%p), unused=%u", bp, 0);
 
     printf("Generated fast log-entries to log-file: %s\n", log);
 }

--- a/use-cases/single-file-C-program/test-main.c
+++ b/use-cases/single-file-C-program/test-main.c
@@ -74,10 +74,15 @@ main(const int argc, const char * argv[])
         }
         printf("L3-logging unit-tests log file: %s\n", logfile);
         l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr=%p), refcount=%d", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
+
+        char *bp = (char *) 0xdeadbabe;
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", bp, 1024);
+
+        bp = (char *) 0xbeefabcd;
+        l3_log_simple("Invalid buffer handle (addr=%p), refcount=%d", bp, 0);
+
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, (void *) 0xdeadbeef);
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, (char *) 0xbeefbabe);
     }
 
     return 0;

--- a/use-cases/single-file-CC-program/test-main.cc
+++ b/use-cases/single-file-CC-program/test-main.cc
@@ -65,10 +65,17 @@ main(const int argc, const char * argv[])
         }
         cout << "L3-logging unit-tests log file: " << logfile << "\n";
         l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr=%p, size=%u)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
+
+        int *lockp = (int *) 0xdeadbabe;
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%u)", lockp, 1024);
+
+        lockp = (int *) 0xbeefabcd;
+        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", lockp, 0);
+
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, (char *) 0xdeadbeef);
+
+        lockp = (int *) 0xbeefbabe;
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, lockp);
     }
 
     return 0;

--- a/use-cases/single-file-Cpp-program/test-main.cpp
+++ b/use-cases/single-file-Cpp-program/test-main.cpp
@@ -66,10 +66,17 @@ main(const int argc, const char * argv[])
         }
         cout << "L3-logging unit-tests log file: " << logfile << "\n";
         l3_log_simple("Simple-log-msg-Args(arg1=%d, arg2=%d)", 1, 2);
-        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", 0xdeadbabe, 1024);
-        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", 0xbeefabcd, 0);
-        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, 0xdeadbeef);
-        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, 0xbeefbabe);
+
+        void *bp = (void *) 0xdeadbabe;
+        l3_log_simple("Potential memory overwrite (addr=%p, size=%d)", bp, 1024);
+
+        bp = (void *) 0xbeefabcd;
+        l3_log_simple("Invalid buffer handle (addr=%p, refcount=%d)", bp, 0);
+
+        bp = (int *) 0xdeadbeef;
+        l3_log_fast("Fast-logging msg1=%d, addr=%p", 10, bp);
+
+        l3_log_fast("Fast-logging msg2=%d, addr=%p", 20, (char *) 0xbeefbabe);
     }
 
     return 0;


### PR DESCRIPTION
This commit lays down the groundwork to re-engage u-benchmarking
programs to compare the overheads of L3-logging v/s, say, logging
via `printf()` or `write()` system call. 

In order to be able to do that, we first need to validate that the print format-specifiers in the 'msg' supplied to l3_log*() are consistent with the arguments supplied.

Currently, several of the use-case and sample programs are coded loosely w/o adhering to this requirement.

This commit implements the following changes:

 - Slighly rearranges calling sequence of L3-logging APIs.
 - Defines DEBUG-version of the caller-macros, which under an `else if (0)` [ dead-code block ] will evaluate to a call to `printf()`.
 - This will trip-up compilation errors in debug-mode builds if any use-case of L3-logging apis have a message with print format-specifiers that are inconsistent with the args supplied.

Requiring that the args-supplied are consistent with the print-format specifiers in the `msg` also makes the job of L3-dump utility lot more reliable and simpler. (It will also help in future
when we do support var-args to the L3-logging apis.)

Bulk of the changes are in `include/l3.h` with minor updates to test programs to conform to the new calling requirements. We still retain required 2-args to the L3-logging call. (Var-args support
will be considered in a future change.)

-----

**NOTE: There are no functional enhancements / changes. Only internal interface refactoring.**