### PR TITLE
[L3] Rename l3__log_simple() -> l3_log_mmap()

### DIFF
--- a/include/l3.h
+++ b/include/l3.h
@@ -67,9 +67,9 @@ int l3_init(const char *path);
 
     #define l3_log_simple(msg, arg1, arg2)                              \
             if (1) {                                                    \
-                l3__log_simple((msg),                                   \
-                               (uint64_t) (arg1), (uint64_t) (arg2),    \
-                                 __LOC__);                              \
+                l3_log_mmap((msg),                                      \
+                            (uint64_t) (arg1), (uint64_t) (arg2),       \
+                            __LOC__);                                   \
             } else if (0) {                                             \
                 printf((msg), (arg1), (arg2));                          \
             } else
@@ -78,9 +78,9 @@ int l3_init(const char *path);
 
     #define l3_log_simple(msg, arg1, arg2)                              \
             if (1) {                                                    \
-                l3__log_simple((msg),                                   \
-                               (uint64_t) (arg1), (uint64_t) (arg2),    \
-                               L3_ARG_UNUSED);                          \
+                l3_log_mmap((msg),                                      \
+                            (uint64_t) (arg1), (uint64_t) (arg2),       \
+                            L3_ARG_UNUSED);                             \
             } else if (0) {                                             \
                 printf((msg), (arg1), (arg2));                          \
             } else
@@ -92,16 +92,16 @@ int l3_init(const char *path);
   #ifdef L3_LOC_ENABLED
 
     #define l3_log_simple(msg, arg1, arg2)                          \
-            l3__log_simple((msg),                                   \
-                           (uint64_t) (arg1), (uint64_t) (arg2),    \
-                           __LOC__)
+            l3_log_mmap((msg),                                      \
+                        (uint64_t) (arg1), (uint64_t) (arg2),       \
+                        __LOC__)
 
   #else   // L3_LOC_ENABLED
 
     #define l3_log_simple(msg, arg1, arg2)                          \
-            l3__log_simple((msg),                                   \
-                           (uint64_t) (arg1), (uint64_t) (arg2),    \
-                           L3_ARG_UNUSED)
+            l3_log_mmap((msg),                                      \
+                        (uint64_t) (arg1), (uint64_t) (arg2),       \
+                        L3_ARG_UNUSED)
 
   #endif  // L3_LOC_ENABLED
 
@@ -124,11 +124,11 @@ extern "C" {
 #endif
 
 #ifdef L3_LOC_ENABLED
-void l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
-                    const loc_t loc);
+void l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
+                 const loc_t loc);
 #else
-void l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
-                    const uint32_t loc);
+void l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
+                 const uint32_t loc);
 #endif  // L3_LOC_ENABLED
 
 #ifdef __cplusplus

--- a/l3_dump.py
+++ b/l3_dump.py
@@ -54,6 +54,13 @@ elif OS_UNAME_S == 'Darwin':
     READELF_STRDUMP_ARG = '-p'
     READELF_DATA_SECTION = '__cstring'
 
+else:
+    # To avoid pylint errors on CI-Mac/OSX builds.
+    READELF_BIN = 'readelf'
+    READELF_HEXDUMP_ARG = '-x'
+    READELF_STRDUMP_ARG = '-p'
+    READELF_DATA_SECTION = '.rodata'
+
 # #############################################################################
 # Enum types defined in src/l3.c for L3_LOG()->{platform, loc_type} fields
 L3_LOG_PLATFORM_LINUX           = 1

--- a/src/l3.c
+++ b/src/l3.c
@@ -232,7 +232,7 @@ l3_mytid(void)
 // ****************************************************************************
 
 /**
- * l3__log_simple() - 'C' interface to "slow" L3-logging.
+ * l3_log_mmap() - 'C' interface to "slow" L3-logging.
  *
  * As 'loc' is an argument synthesized by the caller-macro, under conditional
  * compilation, keep it as the last argument. This makes it possible to define
@@ -241,11 +241,11 @@ l3_mytid(void)
  */
 void
 #ifdef L3_LOC_ENABLED
-l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
-               loc_t loc)
+l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
+            loc_t loc)
 #else
-l3__log_simple(const char *msg, const uint64_t arg1, const uint64_t arg2,
-               uint32_t loc)
+l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
+            uint32_t loc)
 #endif
 {
     int idx = __sync_fetch_and_add(&l3_log->idx, 1) % L3_MAX_SLOTS;


### PR DESCRIPTION
This commit renames lower-level `l3__log_simple()` -> `l3_log_mmap()`, to indicate that the default L3-logging API is to an `mmap()`'ed log-file. There are no other functional changes introduced with this commit.