### PR TITLE
[L3] Introduce l3_log_init() as a shell to call l3_init().

### DIFF
--- a/include/l3.h
+++ b/include/l3.h
@@ -47,6 +47,18 @@
 extern "C" {
 #endif
 
+/**
+ * Different logging interfaces, mainly intended for use by micro-benchmarking
+ * utility programs.
+ */
+typedef enum {
+      L3_LOG_UNDEF      = 0
+    , L3_LOG_MMAP
+    , L3_LOG_FPRINTF
+    , L3_LOG_DEFAULT    = L3_LOG_MMAP
+} l3_log_t;
+
+int l3_log_init(const l3_log_t logtype, const char *path);
 int l3_init(const char *path);
 
 #ifdef __cplusplus

--- a/src/l3.c
+++ b/src/l3.c
@@ -151,7 +151,32 @@ getBaseAddress() {
 }
 #endif  // __APPLE__
 
-// ****************************************************************************
+/**
+ * ****************************************************************************
+ * l3_log_init() - Initialize L3-logging sub-system, selecting the type of
+ * logging to be performed.
+ * ****************************************************************************
+ */
+int
+l3_log_init(const l3_log_t logtype, const char *path)
+{
+    int rv = 0;
+    switch (logtype) {
+      case L3_LOG_MMAP:         // L3_LOG_DEFAULT:
+        rv = l3_init(path);
+        break;
+
+      default:
+        printf("Unsupported L3-logging type=%d\n", logtype);
+        return -1;
+    }
+    return rv;
+}
+
+/**
+ * ****************************************************************************
+ * L3's default logging sub-system, using mmap()'ed files.
+ */
 int
 l3_init(const char *path)
 {

--- a/tests/pytests/l3_dump_test.py
+++ b/tests/pytests/l3_dump_test.py
@@ -27,6 +27,9 @@ if OS_UNAME_S == 'Linux':
 
 elif OS_UNAME_S == 'Darwin':
     EXP_PLATFORM = 2
+else:
+    # To avoid pylint errors on Mac/OSX.
+    EXP_PLATFORM = -1
 
 # #############################################################################
 # Setup some variables pointing to diff dir/sub-dir full-paths.

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -192,7 +192,7 @@ main(int argc, char *argv[])
     // Initialize L3-Logging
 #if L3_ENABLED
     const char *logfile = "/tmp/l3.c-server-test.dat";
-    int e = l3_init(logfile);
+    int e = l3_log_init(L3_LOG_MMAP, logfile);
     if (e) {
         errExit("l3_init");
     }


### PR DESCRIPTION
This commit lays down some boilerplate code to add support for different logging schemes under L3. Introduce enum l3_log_t to specify different logging interfaces, mainly intended for use by micro-benchmarking utility programs. l3_log_init() becomes a shell around l3_init(), which remains the default interface to `init` a L3-logging system, on `mmap()`-ed files.

There are no other functional changes introduced with this commit.