### PR TITLE
[Test] Add run-all-client-server-perf-tests to test.sh

### DIFF
--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -160,10 +160,8 @@ main(int argc, char *argv[])
 
     for (ictr = 0; ictr < niters; ictr++) {
 
-        if ((ictr % L3_100K) == 0) {
-            printf(".");
-            fflush(stdout);
-        }
+        // DEBUG: if ((ictr % L3_100K) == 0) { printf("."); fflush(stdout); }
+
         req.counter = resp.counter;
         req.mtype = REQ_MT_INCR;
 
@@ -203,7 +201,7 @@ main(int argc, char *argv[])
 
     printf("Client: ID=%d Performed %lu (%s) message send/receive operations"
            ", ctr=%" PRIu64 ", Avg. %" PRIu64 " ns/msg"
-           ", throughput=%lu (%s) ops/sec."
+           ", Client-throughput=%lu (%s) ops/sec."
            " Exiting.\n",
             clientId, ictr, value_str(ictr), resp.counter,
             (elapsed_ns / ictr),

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -333,7 +333,7 @@ main(int argc, char *argv[])
                    ", cumu_time_ns=%" PRIu64
                    " (clock_id=%d)"
                    ", Avg. %s time=%" PRIu64 " ns/msg"
-                   ", throughput=%lu (%s) ops/sec"
+                   ", Server-throughput=%lu (%s) ops/sec"
                    ", # active clients=%d\n",
                    req.clientId,
                    clientp->num_ops, value_str(clientp->num_ops),


### PR DESCRIPTION
This commit adds a new catch-all driver test-method, named `run-all-client-server-perf-tests`, to `test.sh`, which can be used to run through all client-server performance tests that are of interest.

This new method is not going to be run in CI as all it does is to execute other test-methods which _are_ executed in CI.

By default, all RPC-perf-tests are run with 5-concurrent clients, each sending 1000 messages to the server.

To make it easy to run dev-test performance benchmarks on dev-boxes, this test-method supports optional parameters:

    - number-of-messages to be sent to the server by each client
    - number-of-concurrent clients banging on the server

Usage:

```
  ./test.sh run-all-client-server-perf-tests [ <num-msgs> [ <num-clients> ] ]
```

### Run all perf tests w/ default 1000 msgs and 5 concurrent clients.
  $ ./test.sh run-all-client-server-perf-tests

### Run all perf tests w/ 1Mil msgs (and 5 concurrent clients)
  $ ./test.sh run-all-client-server-perf-tests $((1000 * 1000))

### Run all perf tests w/ 1Mil msgs and a single-client
  $ ./test.sh run-all-client-server-perf-tests $((1000 * 1000)) 1