### PR TITLE
[Perf] Use -Ofast for release and -Og for debug builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,17 @@ jobs:
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-sample-c-appln-with-LOC-ELF
 
     #! -------------------------------------------------------------------------
+    #  This test will build-and-run -ALL- client-server perf-test, with 1-client
+    #  each sending 1 Million messages to the server. This test-method is
+    #  turned OFF for normal CI-jobs. Enable this, and delete the rest of the
+    #  commands, to validate perf-related changes in a CI-build environment.
+    #  Just run with 1 client as CI-VMs seem to not be very high-powered CPUs.
+    #! -------------------------------------------------------------------------
+    # - name: test-run-all-client-server-perf-tests
+    #   run: |
+    #     BUILD_MODE=${{ matrix.build_type }} ./test.sh run-all-client-server-perf-tests $((1000 * 1000)) 1
+
+    #! -------------------------------------------------------------------------
     #  This test will build-and-run client-server perf-test, with L3-Logging OFF
     #  (baseline) and L3-Logging ON.
     #! -------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -636,9 +636,17 @@ ifeq ($(L3_LOC_ENABLED), $(L3_LOC_ELF_ENCODING))
     INCLUDE += -I ./$(LOC_INCDIR)
 endif
 
+# -----------------------------------------------------------------------------
+# Ref: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+#   -Ofast: Disregard strict standards compliance. Enables all -O3 optimizations.
+#   -Og   : Optimize debugging experience. Should be the optimization level of
+#           choice for the standard edit-compile-debug cycle.
 # use += here, so that extra flags can be provided via the environment
+# -----------------------------------------------------------------------------
 ifeq "$(BUILD_MODE)" "debug"
-    CFLAGS += -DDEBUG
+    CFLAGS += -DDEBUG -Og
+else ifeq "$(BUILD_MODE)" "release"
+     CFLAGS += -Ofast
 endif
 
 # By default, L3-logging is always ON for all programs built here.

--- a/test.sh
+++ b/test.sh
@@ -363,7 +363,7 @@ function build-and-run-sample-c-appln-with-LOC-encoding()
 function run-all-client-server-perf-tests()
 {
     local num_msgs_per_client=1000
-    if [ $# -eq 1 ]; then
+    if [ $# -ge 1 ]; then
         num_msgs_per_client=$1
     fi
 

--- a/use-cases/utils/size_str.h
+++ b/use-cases/utils/size_str.h
@@ -74,7 +74,7 @@ char *
 size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
 
 // Length of output buffer to snprintf()-into size as string w/ unit specifier
-#define SIZE_TO_STR_LEN 20
+#define SIZE_TO_STR_LEN 25
 
 /*
  * ----------------------------------------------------------------------


### PR DESCRIPTION

This commits comments out the `-Ofast` flag added to `Makefile`, which appears to show performance gains when client-server perf tests are run on Linux-VM.

 Add new CI test-method, `test-run-all-client-server-perf-tests`, to run this exercise for 1 Million msgs, 1 client. 

Comment out this test-method, and it can be enabled by dev-engineers who wish to verify perf changes thru CI jobs.

`build.yml`: Add `test-run-all-client-server-perf-tests`

Initial performance benchmarking on Linux-VM for the client-server RPC-msg exerciser shows that:

- For single-client, overhead of L3-logging is ~10-13% (This drop needs further analysis.)

- For multiple clients, overhead of L3-logging is <3%,  which is what is expected.

-------------

## Comparison of performance run on Linux-VM running on a Mac/OSX

The client-server performance test was executed before and after the fix to verify if the use of `-Ofast` has any measurable improvement in server-throughput when L3-logging is enabled as compared to the baseline performance with no L3-logging.

Each client pumps 1 Million messages to the server.

Linux:  Ubuntu 22.04.4 LTS GenuineIntel, 8 CPUs, 15 GB,  Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz

**Units of throughput Metric** is # of millions ops/sec.

### Single-client

For each case, `Pct-Drop` column compares the metric for (a) row v/s lower metric in (b) row.

Run No. |Workload       | Baseline | Pct-Drop  |-Ofast   | Pct-Drop
--------|-----          | ------   | ----------|---------|--------
 1 (a)  | No L3-logging | ~1.54    |           | ~1.61   |
 1 (b)  | L3-logging    | ~1.29    |   16%     | ~1.40   | 13%
 1      |  L3-LOC       | ~1.33    |           | ~1.42   |
 1      |  L3-LOC-ELF   | ~1.30    |           | ~1.44   |
 2 (a)  | No L3-logging | ~1.51    |           | ~1.65   |
 2 (b)  | L3-logging    | ~1.33    |   12%     | ~1.46   | 11%
 2      | L3-LOC        | ~1.25    |           | ~1.36   |
 2      | L3-LOC-ELF    | ~1.40    |           | ~1.32   |
 3 (a)  | No L3-logging | ~1.61    |           | ~1.62   |
 3 (b)  | L3-logging    | ~1.33    |   17%     | ~1.41   | 13%
 3      | L3-LOC        | ~1.38    |           | ~1.37   |
 3      | L3-LOC-ELF    | ~1.32    |           | ~1.46   |
 4 (a)  | No L3-logging | ~1.72    |           | ~1.64   |
 4 (b)  | L3-logging    | ~1.33    |   22%     | ~1.40   | 14%
 4      | L3-LOC        | ~1.36    |           | ~1.34   |
 4      | L3-LOC-ELF    | ~1.25    |           | ~1.31   |
 5 (a)  | No L3-logging | ~1.63    |           | ~1.59   |
 5 (b)  | L3-logging    | ~1.45    |   11%     | ~1.37   | 13%
 5      | L3-LOC        | ~1.40    |           | ~1.39   |
 5      | L3-LOC-ELF    | ~1.31    |           | ~1.49   |
 -------|---------------|----------|-----------|---------|


### 5-Clients metrics

With the `-Ofast` optimization, the avg. drop in throughput in the multi-client
experiments is within the range of 0-3%, which is what is expected to be the
overheads of L3-logging.

Run.No. |Workload       | Baseline | Pct-Drop  |-Ofast   | Pct-Drop
--------|-----          | ------   | ----------|---------|--------
 1 (a)  | No L3-logging | ~1.72    |           | ~1.88   |
 1 (b)  | L3-logging    | ~1.75    |   +2%     | ~1.86   |  1%
 1      |  L3-LOC       | ~1.81    |           | ~1.80   |
 1      |  L3-LOC-ELF   | ~1.68    |           | ~1.78   |
 -------|---------------|----------|-----------|---------|
 2 (a)  | No L3-logging | ~1.88    |           | ~1.92   |
 2 (b)  | L3-logging    | ~1.67    |   11%     | ~1.77   | ~8%
 2      | L3-LOC        | ~1.70    |           | ~1.85   |
 2      | L3-LOC-ELF    | ~1.75    |           | ~1.89   |
 -------|---------------|----------|-----------|---------|
 3 (a)  | No L3-logging | ~1.85    |           | ~1.92   |
 3 (b)  | L3-logging    | ~1.74    |    6%     | ~1.86   | ~3%
 3      | L3-LOC        | ~1.67    |           | ~1.79   |
 3      | L3-LOC-ELF    | ~1.74    |           | ~1.91   |
 -------|---------------|----------|-----------|---------|
 4 (a)  | No L3-logging | ~1.93    |           | ~1.80   |
 4 (b)  | L3-logging    | ~1.78    |   ~8%     | ~1.80   |  0%
 4      | L3-LOC        | ~1.70    |           | ~1.75   |
 4      | L3-LOC-ELF    | ~1.72    |           | ~1.73   |
 -------|---------------|----------|-----------|---------|
 5 (a)  | No L3-logging | ~1.89    |           | ~1.90   |
 5 (b)  | L3-logging    | ~1.80    |   ~5%     | ~1.83   | ~4%
 5      | L3-LOC        | ~1.71    |           | ~1.84   |
 5      | L3-LOC-ELF    | ~1.69    |           | ~1.77   |
 -------|---------------|----------|-----------|---------|