### PR TITLE
[Perf] Extend client-server perf test to invoke L3-fast logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ help::
 	@echo ' make run-cc-tests'
 	@echo ' '
 	@echo 'To build client-server performance test programs and run performance test(s)'
-	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0     make client-server-perf-test  # Baseline'
-	@echo ' make clean && CC=gcc LD=g++                  make client-server-perf-test  # L3-logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1 make client-server-perf-test  # L3+LOC logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2 make client-server-perf-test  # L3+LOC-ELF logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
+	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2     make client-server-perf-test  # L3+LOC-ELF logging'
 	@echo ' '
 	@echo 'Environment variables: '
 	@echo ' BUILD_MODE={release,debug}'
@@ -568,6 +569,13 @@ CLIENT_SERVER_NON_MAIN_SRCS     := $(filter-out $(CLIENT_SERVER_PERF_TESTS_DIR)/
 # If L3-logging is enabled in test-program, need to include core library file
 ifeq ($(L3_ENABLED), $(L3_DEFAULT))
     CLIENT_SERVER_NON_MAIN_SRCS += $(L3_SRC)
+
+# Under L3-logging, invoke the L3-fast logging API, which needs the .S file
+ifeq ($(L3_FASTLOG_ENABLED), 1)
+    CLIENT_SERVER_NON_MAIN_SRCS += $(L3_ASSEMBLY)
+    CFLAGS += -DL3_FASTLOG_ENABLED
+endif
+
 endif
 
 # Name of LOC-generated source file for the client-server perf-test program.

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -197,6 +197,13 @@ main(int argc, char *argv[])
         errExit("l3_init");
     }
 
+    char *l3_log_mode = "<unknown>";
+#if L3_FASTLOG_ENABLED
+    l3_log_mode = "fast ";
+#else
+    l3_log_mode = "";
+#endif  // L3_FASTLOG_ENABLED
+
 // In build -D L3_LOC_ELF_ENABLED and -D L3_LOC_ENABLED are both ON.
 // So, check in this order.
 // Info-message to track how L3-logging is being done by server.
@@ -210,9 +217,9 @@ main(int argc, char *argv[])
 #endif  // L3_LOC_ELF_ENCODING
 
     printf("Start Server, using clock '%s'"
-           ": Initiate L3-logging to log-file '%s'"
+           ": Initiate L3-%slogging to log-file '%s'"
            ", using %s encoding scheme.\n",
-           logfile, loc_scheme, clock_name(clock_id));
+           logfile, l3_log_mode, loc_scheme, clock_name(clock_id));
 
 #else // L3_ENABLED
 
@@ -295,10 +302,18 @@ main(int argc, char *argv[])
             elapsed_ns = (nsec1 - nsec0);           // Elapsed-ns for this op
 
 #if L3_ENABLED
+
             // Record time-consumed. (NOTE: See clarification below.)
+#  if L3_FASTLOG_ENABLED
+            l3_log_fast("Server msg: Increment: ClientID=%d, "
+                        "Thread-CPU-time=%" PRIu64 " ns. (L3-fast-log)",
+                        resp.clientId, elapsed_ns);
+#  else
             l3_log_simple("Server msg: Increment: ClientID=%d, "
                           "Thread-CPU-time=%" PRIu64 " ns.",
                           resp.clientId, elapsed_ns);
+#  endif
+
 #endif // L3_ENABLED
 
             // Reuse variable to reacquire current TS for accumulation.


### PR DESCRIPTION
This commit adds a new perf-test execution mode for the client-server performance u-benchmarking toolkit.

`L3_FASTLOG_ENABLED=1 make client-server-perf-test` will build the programs so that server will invoke l3_log_fast(), when needed.

test.sh: Refactoring.
  - Extend test-build-and-run-client-server-perf-test to also execute a case when L3-fast-logging is invoked.
  - Cleanup: Use local variables instead of hard-coded boolean 0/1s to specify if L3/LOC is enabled  / disabled.

svmsg_file_server.c: Invoke l3_log_fast() under `#if L3_FASTLOG_ENABLED`
  which is supplied by the Makefile build-rules.

### Usage:

Build client/server programs to perform L3-fast logging:

```
$ make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test
```
### Perf u-benchmark results (Linux-VM on Mac): 5 clients, 1Mil messages:

**Units**: Throughput measured on server-side, in terms of Million ops/sec
```
   Workload         Expt-1     Expt-2
   Baseline         ~1.96       ~2.00
   L3-logging       ~1.94       ~1.82
   L3-fast logging  ~1.86       ~1.92
```
The 2nd experiment shows the expected results. There seems to be some fluctuations in these runs, probably owning to the VM.