### PR TITLE
[Perf] Extend client-server perf tests to run fprintf(), write() logging.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,34 @@ jobs:
             sudo apt-get update -y
             sudo apt-get install -y pylint pip
 
+            # spdlog package needs 'fmt' library as a pre-requisite
+            sudo apt-get install -y libfmt-dev/jammy
+            sudo apt-get install -y libspdlog-dev
+
         elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install python
             brew install pylint
 
             # To install llvm-readelf
             brew install llvm
+
+            # spdlog package needs 'fmt' library as a pre-requisite
+            brew install fmt
+            brew install spdlog
+
+            # Check required spdlog and fmt .h files
+            set -x
+            ls -l /opt/homebrew/include/spdlog
+
+            ls -l /opt/homebrew/include/fmt
+
+            ls -l /usr/local/opt
+
+            ls -l /opt/homebrew/include/spdlog/
+
+            ls -l /opt/homebrew/lib/*spdlog*
+
+            set +x
         fi
 
         pip install pytest
@@ -63,6 +85,10 @@ jobs:
             elif [ "$RUNNER_OS" == "macOS" ]; then
                 which llvm-readelf
             fi
+
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-spdlog-sample
+      run: RUN_ON_CI=1 ./test.sh test-build-and-run-spdlog-sample
 
     #! -------------------------------------------------------------------------
     - name: test-test-sh-usages

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,12 @@ help::
 	@echo 'To build client-server performance test programs and run performance test(s)'
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2     make client-server-perf-test  # L3+LOC-ELF logging'
+
 	@echo ' '
 	@echo 'To build L3-sample programs with LOC-enabled and run unit-tests:'
 	@echo ' make clean && CC=gcc LD=g++         L3_LOC_ENABLED=1 make all-c-tests   && L3_LOC_ENABLED=1 make run-c-tests'
@@ -580,6 +582,10 @@ ifeq ($(L3_FASTLOG_ENABLED), 1)
 else ifeq ($(L3_LOGT_FPRINTF), 1)
 
     CFLAGS += -DL3_LOGT_FPRINTF
+
+else ifeq ($(L3_LOGT_WRITE), 1)
+
+    CFLAGS += -DL3_LOGT_WRITE
 
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,15 @@ help::
 	@echo ' make run-cc-tests'
 	@echo ' '
 	@echo 'To build client-server performance test programs and run performance test(s)'
-	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() logging'
-	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2     make client-server-perf-test  # L3+LOC-ELF logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0                  make client-server-perf-test  # Baseline'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1             make client-server-perf-test  # fprintf() logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1               make client-server-perf-test  # write() logging'
+	@echo ' make clean && CC=g++ LD=g++ L3_ENABLED=0 L3_LOGT_SPDLOG=1 make client-server-perf-test  # C++ spdlog logging'
+	@echo ' make clean && CC=g++ LD=g++ L3_ENABLED=0 L3_LOGT_SPDLOG=2 make client-server-perf-test  # C++ spdlog backtrace'
+	@echo ' make clean && CC=gcc LD=g++                               make client-server-perf-test  # L3-logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1          make client-server-perf-test  # L3 Fast logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1              make client-server-perf-test  # L3+LOC logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2              make client-server-perf-test  # L3+LOC-ELF logging'
 	@echo ' '
 	@echo 'To build L3-sample programs with LOC-enabled and run unit-tests:'
 	@echo ' make clean && CC=gcc LD=g++         L3_LOC_ENABLED=1 make all-c-tests   && L3_LOC_ENABLED=1 make run-c-tests'
@@ -116,6 +118,10 @@ UNAME_P := $(shell uname -p)
 CC  ?= gcc
 CXX ?= g++
 LD  ?= gcc
+
+# cc -x flag default specification
+CC_X_FLAG   := c
+CXX_X_FLAG  := c++
 
 # ###################################################################
 # Symbols for L3 SOURCE DIRECTORIES AND FILES, LOC-Generator Package
@@ -432,7 +438,6 @@ $(SPDLOG_EXAMPLE_PROGRAM_BIN): $(SPDLOG_EXAMPLE_PROG_OBJS)
 
 # We need to effectively execute this build command:
 # g++ -I /usr/include/spdlog -o spdlog-Cpp-program test-main.cpp -L ~/Projects/spdlog/build -l spdlog -l fmt
-spdlog-cpp-program: CPPFLAGS = --std=c++17
 
 # Define SPD_INCLUDE to work for Linux / Darwin, based on the install tool used.
 ifeq ($(UNAME_S),Linux)
@@ -456,7 +461,6 @@ else ifeq ($(UNAME_S),Darwin)
 endif
 
 SPD_INCLUDE := $(SPD_INCLUDE_ROOT)/include
-
 spdlog-cpp-program: INCLUDE += -I $(SPD_INCLUDE)
 spdlog-cpp-program: LIBS += $(SPD_LIBS_PATH) -l spdlog -l fmt
 spdlog-cpp-program: $(SPDLOG_EXAMPLE_PROGRAM_BIN)
@@ -603,6 +607,12 @@ all-unit-tests: $(UNIT_TESTBINS)
 # all: all-c-tests all-cpp-tests all-cc-tests all-unit-tests all-loc-tests
 
 # ##############################################################################
+# Build of client-server program in C++ mode overrides this.
+# So, define this only if it's not already set in the build-flow.
+# ##############################################################################
+CPPFLAGS ?= --std=c++11
+
+# ##############################################################################
 # Rules to build-and-run Client-Server message exchange performance tests.
 # ##############################################################################
 
@@ -639,7 +649,28 @@ else ifeq ($(L3_LOGT_WRITE), 1)
 
     CFLAGS += -DL3_LOGT_WRITE
 
-endif
+endif   # L3_FASTLOG_ENABLED, L3_LOGT_FPRINTF, L3_LOGT_WRITE
+
+else ifeq ($(L3_ENABLED), $(L3_DISABLED))
+
+# Rules triggered for client-server program enhanced with spdlog-logging:
+ifeq ($(L3_LOGT_SPDLOG), 1)
+
+    CFLAGS += -DL3_LOGT_SPDLOG
+    # Compile all .c sources using c++ compiler as c++ sources.
+    CC_X_FLAG := $(CXX_X_FLAG)
+    SPD_CPPFLAGS = $(CPPFLAGS)
+    LIBS += -l spdlog -l fmt
+
+else ifeq ($(L3_LOGT_SPDLOG), 2)
+
+    CFLAGS += -DL3_LOGT_SPDLOG_BACKTRACE
+    # Compile all .c sources using c++ compiler as c++ sources.
+    CC_X_FLAG := $(CXX_X_FLAG)
+    SPD_CPPFLAGS = $(CPPFLAGS)
+    LIBS += -l spdlog -l fmt
+
+endif   # L3_LOGT_SPDLOG
 
 endif   # L3_ENABLED
 
@@ -751,8 +782,6 @@ endif
 
 CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -Wfatal-errors -Werror
 
-CPPFLAGS += --std=c++11
-
 LIBS += -ldl
 
 # ##############################################################################
@@ -781,8 +810,8 @@ $(BINDIR)/%/.:
 #
 # For all-test-code, we need to use -I test-code/<subdir>
 # Dependencies for the main executables
-COMPILE.c       = $(CC)  -x c $(CFLAGS) $(INCLUDE) -c
-COMPILE.cpp     = $(CXX) -x c++ $(CPPFLAGS) $(CFLAGS) $(INCLUDE) -c
+COMPILE.c       = $(CC)  -x $(CC_X_FLAG)  $(SPD_CPPFLAGS) $(CFLAGS) $(INCLUDE) -c
+COMPILE.cpp     = $(CXX) -x $(CXX_X_FLAG) $(CPPFLAGS) $(CFLAGS) $(INCLUDE) -c
 COMPILE.cc      = $(CXX) -x c++ $(CFLAGS) $(INCLUDE) -c
 COMPILE.loc.c   = $(LOC_C_CC) $(CFLAGS) $(INCLUDE) -c
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ help::
 	@echo ' '
 	@echo 'To build client-server performance test programs and run performance test(s)'
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
@@ -572,11 +573,17 @@ ifeq ($(L3_ENABLED), $(L3_DEFAULT))
 
 # Under L3-logging, invoke the L3-fast logging API, which needs the .S file
 ifeq ($(L3_FASTLOG_ENABLED), 1)
+
     CLIENT_SERVER_NON_MAIN_SRCS += $(L3_ASSEMBLY)
     CFLAGS += -DL3_FASTLOG_ENABLED
-endif
+
+else ifeq ($(L3_LOGT_FPRINTF), 1)
+
+    CFLAGS += -DL3_LOGT_FPRINTF
 
 endif
+
+endif   # L3_ENABLED
 
 # Name of LOC-generated source file for the client-server perf-test program.
 ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))

--- a/include/l3.h
+++ b/include/l3.h
@@ -64,6 +64,7 @@ extern FILE *  l3_log_fh;       // L3_LOG_FPRINTF: Opened by fopen()
 
 int l3_log_init(const l3_log_t logtype, const char *path);
 int l3_init(const char *path);
+int l3_log_deinit(const l3_log_t logtype);
 const char *l3_logtype_name(l3_log_t logtype);
 
 #ifdef __cplusplus

--- a/include/l3.h
+++ b/include/l3.h
@@ -94,7 +94,16 @@ const char *l3_logtype_name(l3_log_t logtype);
 
    #else   // L3_LOC_ENABLED
 
-    #define l3_log(msg, arg1, arg2)                                     \
+    #if defined(L3_LOGT_FPRINTF)
+
+    #  define l3_log(msg, arg1, arg2) l3_log_fprintf((msg), arg1, arg2) \
+
+    #elif defined(L3_LOGT_WRITE)
+
+    #  define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)   \
+
+    #else
+    #  define l3_log(msg, arg1, arg2)                                   \
             if (1) {                                                    \
                 l3_log_mmap((msg),                                      \
                             (uint64_t) (arg1), (uint64_t) (arg2),       \
@@ -103,33 +112,33 @@ const char *l3_logtype_name(l3_log_t logtype);
                 printf((msg), (arg1), (arg2));                          \
             } else
 
+    #endif  // L3_LOGT_FPRINTF, L3_LOGT_MMAP etc ...
+
   #endif  // L3_LOC_ENABLED
 
 #else   // defined(DEBUG)
 
   #ifdef L3_LOC_ENABLED
 
-    #define l3_log(msg, arg1, arg2)                                 \
-            l3_log_mmap((msg),                                      \
-                        (uint64_t) (arg1), (uint64_t) (arg2),       \
+    #define l3_log(msg, arg1, arg2)                                     \
+            l3_log_mmap((msg),                                          \
+                        (uint64_t) (arg1), (uint64_t) (arg2),           \
                         __LOC__)
 
   #else   // L3_LOC_ENABLED
 
     #if defined(L3_LOGT_FPRINTF)
 
-    #define l3_log_simple(msg, arg1, arg2)                          \
-            l3_log_fprintf((msg), arg1, arg2)
+    #  define l3_log(msg, arg1, arg2) l3_log_fprintf((msg), arg1, arg2) \
 
     #elif defined(L3_LOGT_WRITE)
 
-    #define l3_log_simple(msg, arg1, arg2)                          \
-            l3_log_write((msg), arg1, arg2)
+    #  define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)   \
 
     #else
-    #define l3_log(msg, arg1, arg2)                                 \
-            l3_log_mmap((msg),                                      \
-                        (uint64_t) (arg1), (uint64_t) (arg2),       \
+    #  define l3_log(msg, arg1, arg2)                                   \
+            l3_log_mmap((msg),                                          \
+                        (uint64_t) (arg1), (uint64_t) (arg2),           \
                         L3_ARG_UNUSED)
 
     #endif  // L3_LOGT_FPRINTF, L3_LOGT_MMAP etc ...

--- a/include/l3.h
+++ b/include/l3.h
@@ -55,11 +55,15 @@ typedef enum {
       L3_LOG_UNDEF      = 0
     , L3_LOG_MMAP
     , L3_LOG_FPRINTF
+    , L3_LOGTYPE_MAX
     , L3_LOG_DEFAULT    = L3_LOG_MMAP
 } l3_log_t;
 
+extern FILE *  l3_log_fh;       // L3_LOG_FPRINTF: Opened by fopen()
+
 int l3_log_init(const l3_log_t logtype, const char *path);
 int l3_init(const char *path);
+const char *l3_logtype_name(l3_log_t logtype);
 
 #ifdef __cplusplus
 }
@@ -110,10 +114,18 @@ int l3_init(const char *path);
 
   #else   // L3_LOC_ENABLED
 
+    #if defined(L3_LOGT_FPRINTF)
+
+    #define l3_log_simple(msg, arg1, arg2)                          \
+            l3_log_fprintf((msg), arg1, arg2)
+
+    #else
     #define l3_log(msg, arg1, arg2)                                 \
             l3_log_mmap((msg),                                      \
                         (uint64_t) (arg1), (uint64_t) (arg2),       \
                         L3_ARG_UNUSED)
+
+    #endif  // L3_LOGT_FPRINTF, L3_LOGT_MMAP etc ...
 
   #endif  // L3_LOC_ENABLED
 
@@ -142,6 +154,17 @@ void l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
 void l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
                  const uint32_t loc);
 #endif  // L3_LOC_ENABLED
+
+/**
+ * l3_log_fprintf() - Log a msg to a file using fprintf().
+ */
+static inline void
+l3_log_fprintf(const char *msg, const uint64_t arg1, const uint64_t arg2)
+{
+    fprintf(l3_log_fh, msg, arg1, arg2);
+}
+
+void l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2);
 
 #ifdef __cplusplus
 }

--- a/include/l3.h
+++ b/include/l3.h
@@ -55,6 +55,7 @@ typedef enum {
       L3_LOG_UNDEF      = 0
     , L3_LOG_MMAP
     , L3_LOG_FPRINTF
+    , L3_LOG_WRITE
     , L3_LOGTYPE_MAX
     , L3_LOG_DEFAULT    = L3_LOG_MMAP
 } l3_log_t;
@@ -118,6 +119,11 @@ const char *l3_logtype_name(l3_log_t logtype);
 
     #define l3_log_simple(msg, arg1, arg2)                          \
             l3_log_fprintf((msg), arg1, arg2)
+
+    #elif defined(L3_LOGT_WRITE)
+
+    #define l3_log_simple(msg, arg1, arg2)                          \
+            l3_log_write((msg), arg1, arg2)
 
     #else
     #define l3_log(msg, arg1, arg2)                                 \

--- a/src/l3.c
+++ b/src/l3.c
@@ -129,6 +129,7 @@ static const char * L3_logtype_name[] = {
                           "L3_LOG_unknown"
                         , "L3_LOG_MMAP"
                         , "L3_LOG_FPRINTF"
+                        , "L3_LOG_WRITE"
                 };
 
 L3_STATIC_ASSERT((L3_ARRAY_LEN(L3_logtype_name) == L3_LOGTYPE_MAX),
@@ -138,7 +139,9 @@ L3_STATIC_ASSERT((L3_ARRAY_LEN(L3_logtype_name) == L3_LOGTYPE_MAX),
 L3_LOG *l3_log = NULL;      // L3_LOG_MMAP: Also referenced in l3.S for
                             // fast-logging.
 
-FILE *  l3_log_fh = NULL;  // L3_LOG_FPRINTF: Opened by fopen()
+FILE *  l3_log_fh = NULL;   // L3_LOG_FPRINTF: Opened by fopen()
+
+int     l3_log_fd = -1;     // L3_LOG_WRITE: Opened by open()
 
 /**
  * The L3-dump script expects a specific layout and its parsing routines
@@ -155,6 +158,7 @@ L3_STATIC_ASSERT(offsetof(L3_LOG,slots) == sizeof(L3_ENTRY),
  * ****************************************************************************
  */
 int l3_init_fprintf(const char *path);
+int l3_init_write(const char *path);
 
 
 #if __APPLE__
@@ -193,6 +197,10 @@ l3_log_init(const l3_log_t logtype, const char *path)
 
       case L3_LOG_FPRINTF:
         rv = l3_init_fprintf(path);
+        break;
+
+      case L3_LOG_WRITE:
+        rv = l3_init_write(path);
         break;
 
       default:
@@ -293,6 +301,28 @@ l3_init_fprintf(const char *path)
     return 0;
 }
 
+/**
+ * ****************************************************************************
+ * Initialize L3's logging sub-system to use write() to named `path`.
+ */
+int
+l3_init_write(const char *path)
+{
+    if (!path) {
+        fprintf(stderr, "%s: Invalid arg 'path'=%p\n", __func__, path);
+        return -1;
+    }
+
+    l3_log_fd = open(path, (O_RDWR | O_CREAT), 0666);
+    if (l3_log_fd == -1) {
+        fprintf(stderr, "%s: Error opening log-file at '%p'. Error=%d\n",
+                __func__, path, errno);
+        return -1;
+    }
+    printf("Initialized write() logging to '%s'\n", path);
+    return 0;
+}
+
 // ****************************************************************************
 static pid_t
 l3_mytid(void)
@@ -342,7 +372,7 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
     l3_log->slots[idx].arg2 = arg2;
 }
 
-/*
+/**
  * l3_log_write() - 'C' interface to log L3 log-entries using write()
  */
 void
@@ -364,7 +394,6 @@ l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2)
     }
     return;
 }
->>>>>>> 281b18c (Inline log_fprintf(). Cleanup messages.)
 
 /**
  * l3_logtype_name() - Map log-type ID to its name.

--- a/src/l3.c
+++ b/src/l3.c
@@ -90,14 +90,14 @@ L3_STATIC_ASSERT(sizeof(loc_t) == sizeof(uint32_t),
  * tool / technique can be used to unpack log-entries when dumping the contents
  * of a L3-log file.
  */
-typedef uint8_t platform_t;
+typedef uint8_t platform_u8_t;
 enum platform_t
 {
       L3_LOG_PLATFORM_LINUX             =  ((uint8_t) 1)
     , L3_LOG_PLATFORM_MACOSX            // ((uint8_t) 2)
 };
 
-typedef uint8_t loc_type_t;
+typedef uint8_t loc_type_u8_t;
 enum loc_type_t
 {
       L3_LOG_LOC_NONE                   =  ((uint8_t) 0)

--- a/src/l3.c
+++ b/src/l3.c
@@ -120,7 +120,25 @@ typedef struct l3_log
     L3_ENTRY        slots[L3_MAX_SLOTS];
 } L3_LOG;
 
-L3_LOG *l3_log; // Also referenced in l3.S for fast-logging.
+#define L3_ARRAY_LEN(arr)   (sizeof(arr) / sizeof(*arr))
+
+/**
+ * Support for different 'logging' types under L3's APIs.
+ */
+static const char * L3_logtype_name[] = {
+                          "L3_LOG_unknown"
+                        , "L3_LOG_MMAP"
+                        , "L3_LOG_FPRINTF"
+                };
+
+L3_STATIC_ASSERT((L3_ARRAY_LEN(L3_logtype_name) == L3_LOGTYPE_MAX),
+                  "Incorrect size of array L3_logtype_name[]");
+
+
+L3_LOG *l3_log = NULL;      // L3_LOG_MMAP: Also referenced in l3.S for
+                            // fast-logging.
+
+FILE *  l3_log_fh = NULL;  // L3_LOG_FPRINTF: Opened by fopen()
 
 /**
  * The L3-dump script expects a specific layout and its parsing routines
@@ -128,9 +146,16 @@ L3_LOG *l3_log; // Also referenced in l3.S for fast-logging.
  * L3_LOG{} and L3_ENTRY{}'s size is somewhat of a convenience. They just
  * happen to be of the same size, as of now, hence, this reuse.)
  */
-
 L3_STATIC_ASSERT(offsetof(L3_LOG,slots) == sizeof(L3_ENTRY),
                 "Expected layout of L3_LOG{} is != 32 bytes.");
+
+/**
+ * ****************************************************************************
+ * Function Prototypes
+ * ****************************************************************************
+ */
+int l3_init_fprintf(const char *path);
+
 
 #if __APPLE__
 
@@ -164,6 +189,10 @@ l3_log_init(const l3_log_t logtype, const char *path)
     switch (logtype) {
       case L3_LOG_MMAP:         // L3_LOG_DEFAULT:
         rv = l3_init(path);
+        break;
+
+      case L3_LOG_FPRINTF:
+        rv = l3_init_fprintf(path);
         break;
 
       default:
@@ -242,6 +271,28 @@ l3_init(const char *path)
     return 0;
 }
 
+/**
+ * ****************************************************************************
+ * Initialize L3's logging sub-system to use fprintf() to named `path`.
+ */
+int
+l3_init_fprintf(const char *path)
+{
+    if (!path) {
+        fprintf(stderr, "%s: Invalid arg 'path'=%p\n", __func__, path);
+        return -1;
+    }
+
+    l3_log_fh = fopen(path, "w+");
+    if (!l3_log_fh) {
+        fprintf(stderr, "%s: Error opening log-file at '%p'. Error=%d\n",
+                __func__, path, errno);
+        return -1;
+    }
+    printf("Initialized fprintf() logging to '%s'\n", path);
+    return 0;
+}
+
 // ****************************************************************************
 static pid_t
 l3_mytid(void)
@@ -289,6 +340,41 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
     l3_log->slots[idx].msg = msg;
     l3_log->slots[idx].arg1 = arg1;
     l3_log->slots[idx].arg2 = arg2;
+}
+
+/*
+ * l3_log_write() - 'C' interface to log L3 log-entries using write()
+ */
+void
+l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2)
+{
+    L3_ENTRY le     = {0};
+    L3_ENTRY *lep   = &le;
+
+    lep->tid = l3_mytid();
+
+    lep->msg = msg;
+    lep->arg1 = arg1;
+    lep->arg2 = arg2;
+
+    if (write(l3_log_fd, lep, sizeof(*lep) != sizeof(*lep))) {
+        fprintf(stderr, "%s(): write() failed. errno=%d\n",
+                __func__, errno);
+        return;
+    }
+    return;
+}
+>>>>>>> 281b18c (Inline log_fprintf(). Cleanup messages.)
+
+/**
+ * l3_logtype_name() - Map log-type ID to its name.
+ */
+const char *
+l3_logtype_name(l3_log_t logtype)
+{
+    return (((logtype < 0) || (logtype >= L3_LOGTYPE_MAX))
+             ? L3_logtype_name[L3_LOG_UNDEF]
+             : L3_logtype_name[logtype]);
 }
 
 /**

--- a/src/l3.c
+++ b/src/l3.c
@@ -212,6 +212,43 @@ l3_log_init(const l3_log_t logtype, const char *path)
 
 /**
  * ****************************************************************************
+ * l3_log_deinit() - De-initialize L3-logging sub-system, selecting the type
+ * of logging that was being performed. Finalize the file and close its handle.
+ * ****************************************************************************
+ */
+int
+l3_log_deinit(const l3_log_t logtype)
+{
+    int rv = 0;
+    switch (logtype) {
+      case L3_LOG_MMAP:         // L3_LOG_DEFAULT:
+        rv = munmap(l3_log, sizeof(*l3_log));
+        break;
+
+      case L3_LOG_FPRINTF:
+        fflush(l3_log_fh);
+        rv = fclose(l3_log_fh);
+        break;
+
+      case L3_LOG_WRITE:
+        syncfs(l3_log_fd);
+        rv = close(l3_log_fd);
+        break;
+
+      default:
+        printf("Unsupported L3-logging type=%d\n", logtype);
+        return -1;
+    }
+    if (rv) {
+        fprintf(stderr, "Error closing L3 log-file for logging type '%s'"
+                        ", errno=%d\n",
+                l3_logtype_name(logtype), errno);
+    }
+    return rv;
+}
+
+/**
+ * ****************************************************************************
  * L3's default logging sub-system, using mmap()'ed files.
  */
 int
@@ -313,7 +350,7 @@ l3_init_write(const char *path)
         return -1;
     }
 
-    l3_log_fd = open(path, (O_RDWR | O_CREAT), 0666);
+    l3_log_fd = open(path, (O_RDWR | O_CREAT | O_APPEND), 0666);
     if (l3_log_fd == -1) {
         fprintf(stderr, "%s: Error opening log-file at '%p'. Error=%d\n",
                 __func__, path, errno);

--- a/src/l3.c
+++ b/src/l3.c
@@ -231,7 +231,9 @@ l3_log_deinit(const l3_log_t logtype)
         break;
 
       case L3_LOG_WRITE:
+#if !defined(__APPLE__)
         syncfs(l3_log_fd);
+#endif // !defined(__APPLE__)
         rv = close(l3_log_fd);
         break;
 

--- a/test.sh
+++ b/test.sh
@@ -478,13 +478,13 @@ function test-build-and-run-client-server-perf-test()
     local l3_LOC_disabled=0
 
     echo " "
-    echo "${Me}: Client-server performance testing with L3-logging OFF ${SvrClockArg}:"
+    echo "**** ${Me}: Client-server performance testing with L3-logging OFF ${SvrClockArg}:"
     echo " "
     build-and-run-client-server-perf-test "${num_msgs_per_client}"      \
                                           "${l3_log_disabled}"
 
     echo " "
-    echo "${Me}: Client-server performance testing with L3-logging ON ${SvrClockArg}:"
+    echo "**** ${Me}: Client-server performance testing with L3-logging ON ${SvrClockArg}:"
     echo " "
     build-and-run-client-server-perf-test "${num_msgs_per_client}" \
                                           "${l3_log_enabled}"
@@ -511,7 +511,7 @@ function test-build-and-run-client-server-perf-test()
 
     local nentries=100
     echo " "
-    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+    echo "**** ${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
     echo " "
 
     set -x
@@ -522,6 +522,27 @@ function test-build-and-run-client-server-perf-test()
         | tail -${nentries}
 
     set +x
+
+    echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-fprintf logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_disabled}"      \
+                                          "fprintf"
+
+    echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                           "${l3_log_enabled}"      \
+                                           "${l3_LOC_disabled}"     \
+                                           "write"
+
+    echo " "
+    echo "**** ${Me}: Completed basic client(s)-server communication test."
+    echo " "
+
     local server_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_server"
     local client_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_client"
 
@@ -633,6 +654,7 @@ function build-and-run-client-server-perf-test()
 {
     local num_msgs_per_client=$1
     local l3_enabled=$2
+
     local l3_loc_enabled=
     if [ $# -ge 3 ]; then
         l3_loc_enabled=$3
@@ -669,6 +691,26 @@ function build-and-run-client-server-perf-test()
                     L3_ENABLED=${l3_enabled}        \
                     L3_FASTLOG_ENABLED=1            \
                     BUILD_VERBOSE=1                 \
+                    make client-server-perf-test
+                ;;
+
+            "fprintf")
+                set -x
+                make clean                      \
+                && CC=gcc LD=g++               \
+                    L3_ENABLED=${l3_enabled}    \
+                    BUILD_VERBOSE=1             \
+                    L3_LOGT_FPRINTF=1           \
+                    make client-server-perf-test
+                ;;
+
+            "write")
+                set -x
+                make clean                      \
+                && CC=gcc LD=g++               \
+                    L3_ENABLED=${l3_enabled}    \
+                    BUILD_VERBOSE=1             \
+                    L3_LOGT_WRITE=1             \
                     make client-server-perf-test
                 ;;
 

--- a/test.sh
+++ b/test.sh
@@ -710,6 +710,15 @@ function build-and-run-client-server-perf-test()
     echo " "
     echo "${Me}: $(TZ="America/Los_Angeles" date) Completed basic client(s)-server communication test."
     echo " "
+
+    if [ "${l3_enabled}" = "1" ]; then
+
+        set -x
+
+        du -sh /tmp/l3.c-server-test.dat
+
+        set +x
+    fi
 }
 
 # #############################################################################

--- a/test.sh
+++ b/test.sh
@@ -102,6 +102,7 @@ TestList=(
            "test-build-and-run-client-server-perf-test"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
+           "test-build-and-run-client-server-perf-test-spdlog"
 
            "test-pytests"
 
@@ -441,6 +442,8 @@ function run-all-client-server-perf-tests()
 
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
 
+    test-build-and-run-client-server-perf-test-spdlog "${num_msgs_per_client}"
+
     echo " "
     set -x
     ./scripts/perf_report.py --file "${outfile}"
@@ -644,6 +647,48 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_2()
 }
 
 # #############################################################################
+# Test build-and-run of client-server performance test benchmark,
+# with C++ spdlog logging.
+# #############################################################################
+function test-build-and-run-client-server-perf-test-spdlog()
+{
+    local num_msgs_per_client=1000
+    if [ $# -eq 1 ]; then
+        num_msgs_per_client=$1
+    fi
+    set +x
+
+    if [ "${UNAME_S}" = "Darwin" ]; then
+        echo "${Me}: Client-server performance tests not supported currently on Mac/OSX."
+        return
+    fi
+
+    # spdlog is used here only for performance benchmarking.
+    local l3_log_enabled=0
+    local l3_LOC_enabled=0
+
+    echo " "
+    echo "${Me}: Client-server performance testing with spdlog-logging:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_enabled}"       \
+                                          "spdlog"
+
+    local nentries=100
+    echo " "
+    tail -${nentries} /tmp/l3.c-server-test.dat
+
+    echo " "
+    echo "${Me}: Client-server performance testing with spdlog-backtrace logging:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_enabled}"       \
+                                          "spdlog-backtrace"
+}
+
+# #############################################################################
 # Minion to test-build-and-run-client-server-perf-test(), to actually perform
 # the build and run the client/server application for performance benchmarking.
 #
@@ -668,6 +713,7 @@ function build-and-run-client-server-perf-test()
         l3_log_type=$4
     fi
 
+    echo "${Me}: ${num_msgs_per_client}, '${l3_enabled}', '${l3_loc_enabled}', '${l3_log_type}'"
     set +x
     # Makefile does not implement 'run' step. Do it here manually.
     local server_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_server"
@@ -714,6 +760,26 @@ function build-and-run-client-server-perf-test()
                     L3_ENABLED=${l3_enabled}    \
                     BUILD_VERBOSE=1             \
                     L3_LOGT_WRITE=1             \
+                    make client-server-perf-test
+                ;;
+
+            "spdlog")
+                set -x
+                make clean                          \
+                && CC=g++ LD=g++                    \
+                    L3_ENABLED=${l3_enabled}        \
+                    L3_LOGT_SPDLOG=1                \
+                    BUILD_VERBOSE=1                 \
+                    make client-server-perf-test
+                ;;
+
+            "spdlog-backtrace")
+                set -x
+                make clean                          \
+                && CC=g++ LD=g++                    \
+                    L3_ENABLED=${l3_enabled}        \
+                    L3_LOGT_SPDLOG=2                \
+                    BUILD_VERBOSE=1                 \
                     make client-server-perf-test
                 ;;
 

--- a/test.sh
+++ b/test.sh
@@ -105,6 +105,9 @@ TestList=(
 
            "test-pytests"
 
+           # spdlog-related test methods
+           "test-build-and-run-spdlog-sample"
+
            # Keep these two at the end, so that we can exercise this
            # script in CI with the --from-test interface, to run just
            # these two tests.
@@ -771,6 +774,25 @@ function test-pytests()
     pytest -v
 
     popd
+}
+
+# #############################################################################
+# Build-and-run spdlog sample tutorial program. This test-method validates that
+# the required dependencies for using spdlog, integrated with L3, are met.
+# #############################################################################
+function test-build-and-run-spdlog-sample()
+{
+    make clean && CC=g++ LD=g++ BUILD_VERBOSE=1 make spdlog-cpp-program
+
+    local test_prog="./build/${Build_mode}/bin/use-cases/spdlog-Cpp-program"
+
+    set +x
+    echo " "
+    echo "${Me}: Run spdlog sample program ..."
+    echo " "
+
+    set -x
+    ${test_prog}
 }
 
 # #############################################################################

--- a/use-cases/client-server-msgs-perf/ename.c.inc
+++ b/use-cases/client-server-msgs-perf/ename.c.inc
@@ -10,7 +10,7 @@
 
 // Generated file. cp'ed here from `make all` output of the full repo sources.
 
-static char *ename[] = {
+static const char *ename[] = {
     /*   0 */ "",
     /*   1 */ "EPERM", "ENOENT", "ESRCH", "EINTR", "EIO", "ENXIO",
     /*   7 */ "E2BIG", "ENOEXEC", "EBADF", "ECHILD",

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -105,7 +105,7 @@ main(int argc, char *argv[])
         niters = atoi(argv[1]);
     }
 
-    printf("Client: ID=%d Perform %lu (%s) message-exchanges to"
+    printf("Client ID=%d Perform %lu (%s) message-exchanges to"
            " increment a number"
 #if L3_ENABLED
            ", with L3-logging"

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -210,15 +210,23 @@ main(int argc, char *argv[])
 
     // Initialize L3-Logging
 #if L3_ENABLED
+    char *l3_log_mode = "<unknown>";
     const char *logfile = "/tmp/l3.c-server-test.dat";
-    int e = l3_log_init(L3_LOG_MMAP, logfile);
+    l3_log_t    logtype = L3_LOG_DEFAULT;
+
+#if L3_LOGT_FPRINTF
+    logtype = L3_LOG_FPRINTF;
+#endif
+
+    int e = l3_log_init(logtype, logfile);
     if (e) {
         errExit("l3_init");
     }
 
-    char *l3_log_mode = "<unknown>";
 #if L3_FASTLOG_ENABLED
     l3_log_mode = "fast ";
+#elif L3_LOGT_FPRINTF
+    l3_log_mode = "fprintf() ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -137,9 +137,14 @@ const char * Options_str = "o:dhmprt";
 
 int parse_arguments(const int argc, char *argv[], int *clock_id, char **outfile);
 void print_usage(const char *program, struct option options[]);
+<<<<<<< HEAD
 void printSummaryStats(const char *outfile, const char *run_descr,
                        Client_info *clients, unsigned int num_clients,
                        int clock_id, uint64_t elapsed_ns);
+=======
+void printSummaryStats(Client_info *clients, unsigned int num_clients,
+                       int clock_id, const char * logging_type);
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
 void svr_clock_calibrate(void);
 unsigned svr_clock_overhead(clockid_t clock_id);
@@ -206,7 +211,11 @@ main(int argc, char *argv[])
         errExit("sigaction");
     }
 
+<<<<<<< HEAD
     char run_descr[80];
+=======
+    char *logging_type = "";
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
     // Initialize L3-Logging
 #if L3_ENABLED
@@ -245,6 +254,8 @@ main(int argc, char *argv[])
     const char *loc_scheme = "(no LOC)";
 #endif  // L3_LOC_ELF_ENCODING
 
+    logging_type = (char *) l3_logtype_name(logtype);
+
     printf("Start Server, using clock '%s'"
            ": Initiate L3-%slogging to log-file '%s'"
            ", using %s encoding scheme.\n",
@@ -255,9 +266,15 @@ main(int argc, char *argv[])
 
 #else // L3_ENABLED
 
+<<<<<<< HEAD
     printf("Start Server, using clock ID=%d '%s': No logging.\n",
            clock_id, clock_name(clock_id));
     snprintf(run_descr, sizeof(run_descr), "Baseline - No logging");
+=======
+    logging_type = "no logging";
+    printf("Start Server, using clock ID=%d '%s': %s.\n",
+           clock_id, clock_name(clock_id), logging_type);
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
 #endif // L3_ENABLED
 
@@ -614,9 +631,14 @@ time_metric_name(int clock_id)
  * printSummaryStats() - Aggregate metrics and print summary across all clients.
  */
 void
+<<<<<<< HEAD
 printSummaryStats(const char *outfile, const char *run_descr,
                   Client_info *clients, unsigned int num_clients,
                   int clock_id, uint64_t elapsed_ns)
+=======
+printSummaryStats(Client_info *clients, unsigned int num_clients,
+                  int clock_id, const char *logging_type)
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 {
     size_t  num_ops = 0;
     size_t  sum_throughput = 0;
@@ -625,16 +647,23 @@ printSummaryStats(const char *outfile, const char *run_descr,
         num_ops += clients[cctr].num_ops;
         sum_throughput += clients[cctr].throughput;
     }
+<<<<<<< HEAD
     size_t svr_throughput = (uint64_t) ((num_ops * 1.0 / elapsed_ns)
                                             * L3_NS_IN_SEC);
     size_t cli_throughput = (sum_throughput / num_clients);
 
     printf("For %u clients, %s, num_ops=%lu (%s) ops"
            ", Elapsed time=%lu (%s) ns"
+=======
+    size_t throughput = (uint64_t) ((num_ops * 1.0 / cumu_time_ns)
+                                        * L3_NS_IN_SEC);
+    printf("For %u clients, logtype=%s, num_ops=%lu (%s) ops"
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
            ", Avg. %s time=%lu ns/msg"
            ", Server throughput=%lu (%s) ops/sec"
            ", Client throughput=%lu (%s) ops/sec"
            "\n",
+<<<<<<< HEAD
            num_clients, run_descr, num_ops, value_str(num_ops),
            elapsed_ns, value_str(elapsed_ns),
            time_metric_name(clock_id), (elapsed_ns / num_ops),
@@ -660,4 +689,9 @@ printSummaryStats(const char *outfile, const char *run_descr,
                 elapsed_ns, value_str(elapsed_ns));
         fclose(fh);
     }
+=======
+           num_clients, logging_type, num_ops, value_str(num_ops),
+           time_metric_name(clock_id), (cumu_time_ns / num_ops),
+           throughput, value_str(throughput));
+>>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 }

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -216,6 +216,8 @@ main(int argc, char *argv[])
 
 #if L3_LOGT_FPRINTF
     logtype = L3_LOG_FPRINTF;
+#elif L3_LOGT_WRITE
+    logtype = L3_LOG_WRITE;
 #endif
 
     int e = l3_log_init(logtype, logfile);

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -423,6 +423,12 @@ end_forever_loop:
     if (msgctl(serverId, IPC_RMID, NULL) == -1) {
         errExit("msgctl");
     }
+
+    // Close L3-logging upon exit.
+#if L3_ENABLED
+    l3_log_deinit(logtype);
+#endif  // L3_ENABLED
+
     printf("Server: # active clients=%d (HWM=%d). Exiting.\n",
            NumActiveClients, NumActiveClientsHWM);
 

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -137,14 +137,9 @@ const char * Options_str = "o:dhmprt";
 
 int parse_arguments(const int argc, char *argv[], int *clock_id, char **outfile);
 void print_usage(const char *program, struct option options[]);
-<<<<<<< HEAD
 void printSummaryStats(const char *outfile, const char *run_descr,
                        Client_info *clients, unsigned int num_clients,
                        int clock_id, uint64_t elapsed_ns);
-=======
-void printSummaryStats(Client_info *clients, unsigned int num_clients,
-                       int clock_id, const char * logging_type);
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
 void svr_clock_calibrate(void);
 unsigned svr_clock_overhead(clockid_t clock_id);
@@ -211,11 +206,7 @@ main(int argc, char *argv[])
         errExit("sigaction");
     }
 
-<<<<<<< HEAD
     char run_descr[80];
-=======
-    char *logging_type = "";
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
     // Initialize L3-Logging
 #if L3_ENABLED
@@ -238,6 +229,8 @@ main(int argc, char *argv[])
     l3_log_mode = "fast ";
 #elif L3_LOGT_FPRINTF
     l3_log_mode = "fprintf() ";
+#elif L3_LOGT_WRITE
+    l3_log_mode = "write() ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED
@@ -254,8 +247,6 @@ main(int argc, char *argv[])
     const char *loc_scheme = "(no LOC)";
 #endif  // L3_LOC_ELF_ENCODING
 
-    logging_type = (char *) l3_logtype_name(logtype);
-
     printf("Start Server, using clock '%s'"
            ": Initiate L3-%slogging to log-file '%s'"
            ", using %s encoding scheme.\n",
@@ -266,15 +257,9 @@ main(int argc, char *argv[])
 
 #else // L3_ENABLED
 
-<<<<<<< HEAD
     printf("Start Server, using clock ID=%d '%s': No logging.\n",
            clock_id, clock_name(clock_id));
     snprintf(run_descr, sizeof(run_descr), "Baseline - No logging");
-=======
-    logging_type = "no logging";
-    printf("Start Server, using clock ID=%d '%s': %s.\n",
-           clock_id, clock_name(clock_id), logging_type);
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 
 #endif // L3_ENABLED
 
@@ -637,14 +622,9 @@ time_metric_name(int clock_id)
  * printSummaryStats() - Aggregate metrics and print summary across all clients.
  */
 void
-<<<<<<< HEAD
 printSummaryStats(const char *outfile, const char *run_descr,
                   Client_info *clients, unsigned int num_clients,
                   int clock_id, uint64_t elapsed_ns)
-=======
-printSummaryStats(Client_info *clients, unsigned int num_clients,
-                  int clock_id, const char *logging_type)
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 {
     size_t  num_ops = 0;
     size_t  sum_throughput = 0;
@@ -653,23 +633,16 @@ printSummaryStats(Client_info *clients, unsigned int num_clients,
         num_ops += clients[cctr].num_ops;
         sum_throughput += clients[cctr].throughput;
     }
-<<<<<<< HEAD
     size_t svr_throughput = (uint64_t) ((num_ops * 1.0 / elapsed_ns)
                                             * L3_NS_IN_SEC);
     size_t cli_throughput = (sum_throughput / num_clients);
 
     printf("For %u clients, %s, num_ops=%lu (%s) ops"
            ", Elapsed time=%lu (%s) ns"
-=======
-    size_t throughput = (uint64_t) ((num_ops * 1.0 / cumu_time_ns)
-                                        * L3_NS_IN_SEC);
-    printf("For %u clients, logtype=%s, num_ops=%lu (%s) ops"
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
            ", Avg. %s time=%lu ns/msg"
            ", Server throughput=%lu (%s) ops/sec"
            ", Client throughput=%lu (%s) ops/sec"
            "\n",
-<<<<<<< HEAD
            num_clients, run_descr, num_ops, value_str(num_ops),
            elapsed_ns, value_str(elapsed_ns),
            time_metric_name(clock_id), (elapsed_ns / num_ops),
@@ -695,9 +668,4 @@ printSummaryStats(Client_info *clients, unsigned int num_clients,
                 elapsed_ns, value_str(elapsed_ns));
         fclose(fh);
     }
-=======
-           num_clients, logging_type, num_ops, value_str(num_ops),
-           time_metric_name(clock_id), (cumu_time_ns / num_ops),
-           throughput, value_str(throughput));
->>>>>>> 53da764 (Rework test.sh to invoke fprintf/write logging. Improve info-msgs.)
 }

--- a/use-cases/spdlog-Cpp-program/test-main.cpp
+++ b/use-cases/spdlog-Cpp-program/test-main.cpp
@@ -1,0 +1,76 @@
+/**
+ * *****************************************************************************
+ * spdlog-Cpp-program/test-main.cpp: spdlog example program.
+ *
+ * Developed based on docs / examples from spdlog repo
+ * References:
+ *  [1] https://github.com/gabime/spdlog
+ *  [2] https://github.com/gabime/spdlog/blob/v1.x/example/example.cpp
+ *
+ * ---- Build Instructions: ----
+ *
+ * $ sudo apt-get install -y libfmt-dev/jammy   # Pre-requisite 'fmt' library
+ * $ sudo apt-get install -y libspdlog-dev
+ *
+ * $ cd ~/Projects/
+ * $ git clone https://github.com/gabime/spdlog.git
+ * $ cd spdlog && mkdir build && cd build
+ * $ cmake .. && make -j
+ *
+ * Now build this test program using the library built above.
+ * $ g++ -I /usr/include/spdlog -o spdlog-Cpp-program test-main.cpp -L ~/Projects/spdlog/build -l spdlog -l fmt
+ * *****************************************************************************
+ */
+#include <iostream>
+#include "spdlog/spdlog.h"
+
+#include "spdlog/sinks/basic_file_sink.h"
+using namespace std;
+
+void
+basic_example(void)
+{
+    // Create basic file logger (not rotated).
+    string logfile = "/tmp/basic-log.txt";
+    auto my_logger = spdlog::basic_logger_mt("file_logger", logfile, true);
+    my_logger->info("Welcome to spdlog!");
+    my_logger->critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
+    cout << "spdlog messages can be found in '" << logfile << "'\n";
+}
+
+/**
+ * Debug messages can be stored in a ring buffer instead of being logged
+ * immediately. This is useful to display debug logs only when needed
+ * (e.g. when an error happens).
+ * When needed, call dump_backtrace() to dump them to your log.
+ */
+void
+backtrace_example(void)
+{
+    spdlog::enable_backtrace(32); // Store the latest 32 messages in a buffer.
+    // or my_logger->enable_backtrace(32)..
+    for(int i = 0; i < 100; i++)
+    {
+        spdlog::debug("Backtrace message {}", i); // not logged yet..
+    }
+    // e.g. if some error happened:
+    spdlog::dump_backtrace(); // log them now! show the last 32 messages
+    // or my_logger->dump_backtrace(32)..
+}
+
+int
+main()
+{
+    cout << "Hello world\n";
+    spdlog::info("Welcome to spdlog!");
+    spdlog::error("Some error message with arg: {}", 1);
+    spdlog::warn("Easy padding in numbers like {:08d}", 12);
+    spdlog::critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
+    spdlog::info("Support for floats {:03.2f}", 1.23456);
+    spdlog::info("Positional args are {1} {0}..", "too", "supported");
+    spdlog::info("{:<30}", "left aligned");
+
+    backtrace_example();
+
+    basic_example();
+}

--- a/use-cases/utils/size_str.c
+++ b/use-cases/utils/size_str.c
@@ -37,7 +37,7 @@ size_to_str(char *outbuf, size_t outbuflen, size_t size)
    size_t frac_val  = 0;
    int is_approx = false;
 
-   char *units = NULL;
+   const char *units = NULL;
    if (size >= SZ_TiB) {
       unit_val  = SZ_B_TO_TiB(size);
       frac_val  = SZ_B_TO_TiB_FRACT(size);
@@ -100,7 +100,7 @@ value_to_str(char *outbuf, size_t outbuflen, size_t value)
    size_t frac_val  = 0;
    int is_approx = false;
 
-   char *units = NULL;
+   const char *units = NULL;
    if (value >= VAL_Trillion) {
       unit_val  = VAL_N_TO_Trillion(value);
       frac_val  = VAL_N_TO_Trillion_FRACT(value);


### PR DESCRIPTION
This PR is a collection of incremental changes to run basic client-server message execution tests with different forms of logging on the server-side.

1. Baseline: No logging.
2. L3-logging
3. L3-fast logging
4. L3-fprintf() logging
5. L3-write() logging
6. L3-LOC logging
7. L3-LOC-ELF logging
8. spdlog logging to a file
9. spdlog-backtrace logging (to in-memory ring buffer)

All workloads can be executed using one top-level command as follows:

```
$ ./test.sh run-all-client-server-perf-tests [ server-clock-ID [ num-msgs [ num-clients ] ] ]
```

Defaults: num-msgs=1000, num-clients=5

To run a heavy-workload, exec `$ ./test.sh run-all-client-server-perf-tests --clock-default $((1000 * 1000))`

To run a heavy single-clientworkload, exec `$ ./test.sh run-all-client-server-perf-tests --clock-default $((1000 * 1000)) 1`


## Sample results

### Linux-VM (Running on a Mac):

```
+ ./scripts/perf_report.py --file /tmp/test.sh.run-all-client-server-perf-tests.out
    **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+-------------------------------+-------------------+----------+-------------------+----------+
| Run-Type                      | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+-------------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging         | ~100.08 K ops/sec |  0.00 %  |  ~22.80 K ops/sec |  0.00 %  |
| L3-logging (no LOC)           | ~100.60 K ops/sec |  0.51 %  |  ~23.31 K ops/sec |  2.22 %  |
| L3-fast logging (no LOC)      |  ~95.14 K ops/sec | -4.94 %  |  ~21.54 K ops/sec | -5.51 %  |
| L3-fprintf() logging (no LOC) |  ~92.10 K ops/sec | -7.98 %  |  ~20.42 K ops/sec | -10.42 % |
| L3-write() logging (no LOC)   |  ~92.57 K ops/sec | -7.51 %  |  ~20.45 K ops/sec | -10.32 % |
| L3-logging default LOC        | ~102.89 K ops/sec |  2.81 %  |  ~24.17 K ops/sec |  6.03 %  |
| L3-logging LOC-ELF            | ~104.83 K ops/sec |  4.74 %  |  ~24.81 K ops/sec |  8.81 %  |
| spdlog-logging                |  ~89.65 K ops/sec | -10.43 % |  ~20.01 K ops/sec | -12.22 % |
| spdlog-backtrace-logging      |  ~93.55 K ops/sec | -6.53 %  |  ~20.92 K ops/sec | -8.23 %  |
+-------------------------------+-------------------+----------+-------------------+----------+
+ set +x

test.sh: Tue May 28 12:20:01 AM PDT 2024 Completed all client(s)-server communication test [ 0h 8m 10s ].

```

### Linux-Docker  (Running on a Mac):

```
+ ./scripts/perf_report.py --file /tmp/test.sh.run-all-client-server-perf-tests.out

    **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+-------------------------------+-------------------+----------+-------------------+----------+
| Run-Type                      | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+-------------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging         |  ~60.18 K ops/sec |  0.00 %  |  ~12.89 K ops/sec |  0.00 %  |
| L3-logging (no LOC)           |  ~55.83 K ops/sec | -7.22 %  |  ~12.41 K ops/sec | -3.78 %  |
| L3-fast logging (no LOC)      |  ~49.14 K ops/sec | -18.34 % |  ~12.23 K ops/sec | -5.18 %  |
| L3-fprintf() logging (no LOC) |  ~40.27 K ops/sec | -33.07 % |  ~9.56 K ops/sec  | -25.84 % |
| L3-write() logging (no LOC)   |  ~56.10 K ops/sec | -6.77 %  |  ~12.10 K ops/sec | -6.16 %  |
| L3-logging default LOC        |  ~57.66 K ops/sec | -4.18 %  |  ~12.46 K ops/sec | -3.34 %  |
| L3-logging LOC-ELF            |  ~50.83 K ops/sec | -15.53 % |  ~11.09 K ops/sec | -14.02 % |
| spdlog-logging                |  ~51.23 K ops/sec | -14.86 % |  ~11.79 K ops/sec | -8.54 %  |
| spdlog-backtrace-logging      |  ~52.80 K ops/sec | -12.26 % |  ~12.15 K ops/sec | -5.76 %  |
+-------------------------------+-------------------+----------+-------------------+----------+
+ set +x

test.sh: Tue May 28 00:37:29 PDT 2024 Completed all client(s)-server communication test [ 0h 15m 44s ].
```

### Benchmarking results on Linux-workstation

From: Greg Law <greg@undo.io>
To: Aditya Gurajada <adityagurajada@yahoo.com>
Sent: Tuesday, May 28, 2024 at 04:03:40 AM PDT
Subject: Re: Pending reviews for L3-LOC integration (your attention is requested)

Awesome stuff! I'm seeing a bit of variability on my system, even with turbo boost disabled, but the numbers broadly make sense. I think it probably wants multiple runs and take the median of each. Or I could try with many more iterations. But it's all making good sense I think. Here are three runs with no other programs running and turbo disabled:

```
   **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+-------------------------------+-------------------+----------+-------------------+----------+
| Run-Type                      | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+-------------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging         | ~309.05 K ops/sec |  0.00 %  |  ~90.36 K ops/sec |  0.00 %  |
| L3-logging (no LOC)           | ~306.51 K ops/sec | -0.82 %  |  ~90.11 K ops/sec | -0.27 %  |
| L3-fast logging (no LOC)      | ~307.95 K ops/sec | -0.36 %  |  ~90.33 K ops/sec | -0.03 %  |
| L3-fprintf() logging (no LOC) | ~290.53 K ops/sec | -5.99 %  |  ~82.81 K ops/sec | -8.36 %  |
| L3-write() logging (no LOC)   | ~288.82 K ops/sec | -6.54 %  |  ~82.02 K ops/sec | -9.23 %  |
| L3-logging default LOC        | ~308.20 K ops/sec | -0.27 %  |  ~91.17 K ops/sec |  0.89 %  |
| L3-logging LOC-ELF            | ~301.70 K ops/sec | -2.38 %  |  ~87.73 K ops/sec | -2.91 %  |
| spdlog-logging                | ~263.72 K ops/sec | -14.66 % |  ~72.01 K ops/sec | -20.31 % |
| spdlog-backtrace-logging      | ~278.42 K ops/sec | -9.91 %  |  ~77.42 K ops/sec | -14.32 % |
+-------------------------------+-------------------+----------+-------------------+----------+
```

``` 
   **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+-------------------------------+-------------------+----------+-------------------+----------+
| Run-Type                      | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+-------------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging         | ~309.13 K ops/sec |  0.00 %  |  ~90.28 K ops/sec |  0.00 %  |
| L3-logging (no LOC)           | ~307.91 K ops/sec | -0.40 %  |  ~91.09 K ops/sec |  0.90 %  |
| L3-fast logging (no LOC)      | ~301.87 K ops/sec | -2.35 %  |  ~88.20 K ops/sec | -2.30 %  |
| L3-fprintf() logging (no LOC) | ~290.18 K ops/sec | -6.13 %  |  ~82.67 K ops/sec | -8.42 %  |
| L3-write() logging (no LOC)   | ~290.70 K ops/sec | -5.96 %  |  ~82.54 K ops/sec | -8.57 %  |
| L3-logging default LOC        | ~307.83 K ops/sec | -0.42 %  |  ~90.19 K ops/sec | -0.10 %  |
| L3-logging LOC-ELF            | ~300.50 K ops/sec | -2.79 %  |  ~87.77 K ops/sec | -2.78 %  |
| spdlog-logging                | ~265.67 K ops/sec | -14.06 % |  ~72.58 K ops/sec | -19.61 % |
| spdlog-backtrace-logging      | ~281.91 K ops/sec | -8.81 %  |  ~78.74 K ops/sec | -12.78 % |
+-------------------------------+-------------------+----------+-------------------+----------+
```
 
```
   **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+-------------------------------+-------------------+----------+-------------------+----------+
| Run-Type                      | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+-------------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging         | ~309.34 K ops/sec |  0.00 %  |  ~90.98 K ops/sec |  0.00 %  |
| L3-logging (no LOC)           | ~306.57 K ops/sec | -0.90 %  |  ~89.29 K ops/sec | -1.85 %  |
| L3-fast logging (no LOC)      | ~311.80 K ops/sec |  0.79 %  |  ~91.46 K ops/sec |  0.53 %  |
| L3-fprintf() logging (no LOC) | ~286.42 K ops/sec | -7.41 %  |  ~81.35 K ops/sec | -10.58 % |
| L3-write() logging (no LOC)   | ~288.93 K ops/sec | -6.60 %  |  ~81.69 K ops/sec | -10.21 % |
| L3-logging default LOC        | ~309.11 K ops/sec | -0.07 %  |  ~90.84 K ops/sec | -0.15 %  |
| L3-logging LOC-ELF            | ~308.51 K ops/sec | -0.27 %  |  ~90.45 K ops/sec | -0.57 %  |
| spdlog-logging                | ~268.27 K ops/sec | -13.28 % |  ~73.48 K ops/sec | -19.23 % |
| spdlog-backtrace-logging      | ~278.84 K ops/sec | -9.86 %  |  ~77.57 K ops/sec | -14.73 % |
+-------------------------------+-------------------+----------+-------------------+----------+
```