### PR TITLE
Makefile and test.sh changes to build L3 on Docker images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -688,6 +688,8 @@ CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -Wfatal-errors -Werror
 
 CPPFLAGS += --std=c++11
 
+LIBS += -ldl
+
 # ##############################################################################
 # Automatically create directories, based on
 # http://ismail.badawi.io/blog/2017/03/28/automatic-directory-creation-in-make/

--- a/samples/sample-c-appln/Makefile
+++ b/samples/sample-c-appln/Makefile
@@ -44,6 +44,8 @@ SOURCES     := main.c functions.c
 
 CFLAGS       = -O3
 
+LIBS        += -ldl
+
 # Also include L3's include files' dir-path.
 INCLUDE += -I $(PROJECT_ROOT_DIR) -I ./$(L3_INCDIR)
 
@@ -131,7 +133,7 @@ all: $(C_SAMPLES_LOC_GENSRC) $(SOURCES) $(TARGET)
 	$(CC) $(CFLAGS) $(DFLAGS) $(INCLUDE) -o $@ -c $<
 
 $(TARGET): $(C_SAMPLES_LOC_GENSRC) $(OBJS)
-	$(CC) $(LFLAGS) $(OBJS) $(LDFLAGS) $(L3_ASSEMBLY) -o $(TARGET)
+	$(CC) $(LFLAGS) $(OBJS) $(LDFLAGS) $(L3_ASSEMBLY) -o $(TARGET) $(LIBS)
 	./$(TARGET)
 
 purge: clean

--- a/test.sh
+++ b/test.sh
@@ -333,7 +333,8 @@ function build-and-run-sample-c-appln-with-LOC-encoding()
 
     local program="./c-sample"
 
-    make clean && L3_LOC_ENABLED=${loc_encoding}  make c-sample
+    L3_LOC_ENABLED=${loc_encoding} make clean
+    L3_LOC_ENABLED=${loc_encoding} make c-sample
 
     set +x
 


### PR DESCRIPTION
This commit implements couple of minor fixes to get the L3 sources and tests running cleanly on a privately-built Docker image. This is running Ubuntu 20.04.5 LTS/focal version.