### PR TITLE
[Perf] Revise 'time-consumed' tracking on server-side.

### DIFF
--- a/use-cases/client-server-msgs-perf/svmsg_file.h
+++ b/use-cases/client-server-msgs-perf/svmsg_file.h
@@ -42,8 +42,7 @@ typedef enum {
       REQ_MT_UNKNOWN    = 0
     , REQ_MT_INIT       = 1     // New client initialization
     , REQ_MT_INCR               // Increment client's counter
-    , REQ_MT_DECR               // Decrement client's counter
-    , REQ_MT_GET_CTR            // Retrieve current state of counter
+    , REQ_MT_SET_THROUGHPUT     // Record client's avg throughput nops/sec
     , REQ_MT_QUIT               // This client wants to quit
 
     // Server will send RESP_MT_QUIT to all active clients.
@@ -54,7 +53,6 @@ typedef enum {
     , RESP_MT_DATA              // Message contains data (counter)
     , RESP_MT_END               // End of message stream (unused)
     , RESP_MT_INCR  = REQ_MT_INCR
-    , RESP_MT_DECR  = REQ_MT_DECR
     , RESP_MT_QUIT  = REQ_MT_QUIT
 
 } req_resp_type_t;

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -166,28 +166,22 @@ main(int argc, char *argv[])
     int     serverId;
     struct sigaction sa;
 
-    // On MacOSX, only the CLOCK_THREAD_CPUTIME_ID clock has a resolution of 1ns.
-    // On Linux, all clocks seem to have 1 ns resolution, so, default is to also
-    // use the same CLOCK_THREAD_CPUTIME_ID.
-    int clock_id;
-
 #if __APPLE__
     printf("%s is currently not supported on Mac/OSX\n", argv[0]);
     exit(EXIT_SUCCESS);
 #endif
 
-    // Default, so throughput (nops/sec) is consistent with normal expectation.
-    clock_id = CLOCK_REALTIME;
+    // On MacOSX, only the CLOCK_THREAD_CPUTIME_ID clock has a resolution of 1ns.
+    // On Linux, all clocks seem to have 1 ns resolution, so, default is to
+    // use the CLOCK_REALTIME, so throughput (nops/sec) is metris's calculation
+    // is consistent with normal expectation.
+    int clock_id = CLOCK_REALTIME;
 
     // Arg-parsing is only supported on Linux.
     int rv = parse_arguments(argc, argv, &clock_id);
     if (rv) {
         errExit("Argument error.");
     }
-
-#if !defined(L3_ENABLED)
-    svr_clock_calibrate();
-#endif  // L3_ENABLED
 
     /* Create server message queue */
 
@@ -401,6 +395,12 @@ end_forever_loop:
 
     printSummaryStats(run_descr, ActiveClients, NumActiveClientsHWM, clock_id,
                       elapsed_ns);
+
+    // For visibility into how clocks are performing on user's machine,
+    // run clock-calibration after all workload / metrics collection is done.
+#if !defined(L3_ENABLED)
+    svr_clock_calibrate();
+#endif  // L3_ENABLED
 
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
This commit simplifies the time-tracking fields for each client. Previously, we tried to track two different times:

 1. CPU-clock-time for implementing the actual op
 2. Real-time-clock-time for the whole process including the overheads of logging.

The idea was to measure (1) [ w/o logging ] and to track it as one of the arguments to the subsequent l3_log() call.

Another attempt made was to convert the cumulative [2] time to a throughput metric (num-ops / sec). But trying to mix these two time-tracking schemes, and jostle between `clock_gettime()` calls got confusing and needlessly unreliable.

This commit simplifies everything as follows.

Implement the code as:

```
  a) clock_gettime() ◁----------------------------+
  b) Do the n-operations in a forever-loop        |--> time measured for
  c) Log, if needed [ Absent in baseline runs ]   | configured clock
  d) clock_gettime() ◁----------------------------+
```

This commit reworks the time-tracking fields for each side of the transmission.  We just use the elapsed time between (d) and (a) to compute the overall throughput.

**Client**: Get CLOCK_REALTIME for the entire n-messages and generate client-side throughput. This will measure
  the impact of L3-logging on real-time throughput.

  When client-exits, report back its throughput to the server.

**Server**: Use CLOCK_REALTIME as default clock.  Start timer before forever-loop waiting for messsges from
  the clients. End the timer when all clients exit.

  Assuming that clients are continually pumping messages, this is a reasonable way to measure overall elapsed-time.

  Server will report avg throughput across all clients.

The server program has already been extended to support cmdline flags to select the type of clock to use.

So, with this support, one can run the server as `svmsg_file_server --clock-process-cputime-id` to run through the
u-benchmarking using the CLOCK_PROCESS_CPUTIME_ID clock, to get a read-into the timing metrics using that clock. Default clock is `CLOCK_REALTIME`.

test.sh: Driver script is enhanced to run various perf-bm tests, varying
  the run-parameters. See `./test.sh --help` for detailed usage info.
  Fix shellcheck errors.

- Added svr_clock_calibrate() & svr_clock_overhead() to run thru clock calibration on test machine.

- Improved / expanded msgs reporting metrics / summary.

With this rework, all perf-test-methods will report the client-and server-side throughput using real-time elapsed, aggregating across c-clients and n-messages.

Tests can be run using, say, --clock-process-cputime-id flag, to generate the overhead due to logging in terms of CPU-time spent when L3 is enabled. Throughput reported on server-side is also scaled based on CPU-time-ns elapsed.

-----

### NOTE TO THE REVIEWER

@gregthelaw -- I have updated the instructions in the [L3‐Performance-Benchmarking]() Wiki page to reflect the interface changes introduced by this change-set. 

You should be able to download this dev-branch and follow those instructions to re-run these u-benchmarking tests on your Linux workstation.

-----

#### Results from latest iteration of fix:

5-concurrent clients, sending 1 Million messages to the server:

- Using real-time clock on both client and server-side:

```
agurajada-Linux-Vm:[195] $ egrep -E 'Server throughput' ~/tmp/run-all-perf.client-svr-throughput.1Mil.5ct.out| cut -f2,6,7 -d','
 No logging, Server throughput=98569 (~98.56 K) ops/sec, Client throughput=23569 (~23.56 K) ops/sec
 L3-logging (no LOC), Server throughput=100628 (~100.62 K) ops/sec, Client throughput=22690 (~22.69 K) ops/sec
 L3-fast logging (no LOC), Server throughput=103407 (~103.40 K) ops/sec, Client throughput=24236 (~24.23 K) ops/sec
 L3-logging default LOC, Server throughput=103843 (~103.84 K) ops/sec, Client throughput=25804 (~25.80 K) ops/sec
 L3-logging LOC-ELF, Server throughput=103263 (~103.26 K) ops/sec, Client throughput=23565 (~23.56 K) ops/sec
```

- Using real-time clock on client-side and CPU-time clock on server-side:

```
agurajada-Linux-Vm:[196] $ egrep -E 'Server throughput' ~/tmp/run-all-perf.client-svr-throughput.CPU-time.1Mil.5ct.out | cut -f2,6,7 -d','
 No logging, Server throughput=122093 (~122.09 K) ops/sec, Client throughput=23415 (~23.41 K) ops/sec
 L3-logging (no LOC), Server throughput=127401 (~127.40 K) ops/sec, Client throughput=24266 (~24.26 K) ops/sec
 L3-fast logging (no LOC), Server throughput=121472 (~121.47 K) ops/sec, Client throughput=23918 (~23.91 K) ops/sec
 L3-logging default LOC, Server throughput=122455 (~122.45 K) ops/sec, Client throughput=23655 (~23.65 K) ops/sec
 L3-logging LOC-ELF, Server throughput=129966 (~129.96 K) ops/sec, Client throughput=25562 (~25.56 K) ops/sec
```

The diff in throughput comparing baseline with L3-logging enabled is inline with expected ranges of 2-4% drop.

In some runs, the throughput with L3-logging enabled goes up, but this may be an aberration of timing computations and due to the use of the VM.

------


#### Results from previous iteration of fix (can be discarded eventually):

Here is a sample output on my Linux-VM:

- Throughput metrics using the CLOCK_REALTIME clock:

```
agurajada-Linux-Vm:[122] $ grep "msg, throughput=" ~/tmp/run-all-perf.defaults.1Mil.5ct.out | cut -f2,6 -d','
 No logging, throughput=33991082 (~33.99 Million) ops/sec
 L3-logging (no LOC), throughput=21455900 (~21.45 Million) ops/sec
 L3-fast logging (no LOC), throughput=18753585 (~18.75 Million) ops/sec
 L3-logging default LOC, throughput=20511098 (~20.51 Million) ops/sec
 L3-logging LOC-ELF, throughput=18114519 (~18.11 Million) ops/sec
```

Drop from ~33.99 to ~21.45 million ops/sec w/L3-logging enable: Drop of ~37%.

- Throughput metrics using the CLOCK_PROCESS_CPUTIME_ID clock:

```
agurajada-Linux-Vm:[119] $ grep "msg, throughput=" ~/tmp/run-all-perf.process-CPU-time.1Mil.5ct.out | cut -f2,6 -d','
 No logging, throughput=2983442 (~2.98 Million) ops/sec
 L3-logging (no LOC), throughput=2840394 (~2.84 Million) ops/sec
 L3-fast logging (no LOC), throughput=2900842 (~2.90 Million) ops/sec
 L3-logging default LOC, throughput=2995347 (~2.99 Million) ops/sec
 L3-logging LOC-ELF, throughput=2682040 (~2.68 Million) ops/sec
```

Drop from ~2.98 to ~2.84 million ops/sec w/L3-logging enable: Drop of ~4.6%, which is "in-line" with the drop expected w/L3 enabled.

**Help**: The puzzling thing for me is why the throughput metric drops so much when computed using real-time. I suppose that's to be expected, but would like to get your eyes to review that there are no code / logic / computation errors.