### PR TITLE
[Perf] Generate performance comparison report from one-line metrics summary.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,13 @@ jobs:
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_2
 
     # -------------------------------------------------------------------------
+    # Exercise the do-it-all perf-tests method, which is really intended for
+    # use by developers, to benchmark with large # of messages. A default
+    # invocation will run with small # clients & messages.
+    - name: test-run-all-client-server-perf-tests
+      run: ./test.sh run-all-client-server-perf-tests
+
+    # -------------------------------------------------------------------------
     # Exercise the --from-test interface to verify that it still works to
     # run thru last pair of code-formatting tests. (Minor duplication of
     # these two low-impact tests.)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         fi
 
         pip install pytest
+        pip install prettytable
 
         set -x
         echo " "

--- a/scripts/perf_report.py
+++ b/scripts/perf_report.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Python script to parse file containing one-line summary of metrics from
+client-server performance u-benchmarking tests.
+Generate summary comparison report.
+
+Date 2024-05-25
+Copyright (c) 2024
+"""
+import sys
+import argparse
+from collections import OrderedDict
+from prettytable import PrettyTable
+
+###############################################################################
+# main() driver
+###############################################################################
+def main():
+    """
+    Shell to call do_main() with command-line arguments.
+    """
+    do_main(sys.argv[1:])
+
+###############################################################################
+# pylint: disable-msg=too-many-locals
+def do_main(args:list):
+    """
+    Main method that drives parsing the input file to generate the report.
+    Each line is of the format:
+     - Multiple comma-separated fields
+     - Each field may is '='-separated, like so; "<metric>=<value> (<text>)"
+
+# pylint: disable=line-too-long
+
+Baseline - No logging, NumClients=5, NumOps=5000000 (5 Million), Server throughput=91795 (~91.79 K) ops/sec, Client throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 (~54.46 Billion) ns
+
+L3-logging (no LOC), NumClients=5, NumOps=5000000 (5 Million), Server throughput=98602 (~98.60 K) ops/sec, Client throughput=24414 (~24.41 K) ops/sec, elapsed_ns=50708895912 (~50.70 Billion) ns
+
+# pylint: enable=line-too-long
+    Parse each comma-separated fields and extract values.
+    """
+    parsed_args = perf_parse_args(args)
+    perf_file = parsed_args.file
+    lctr = 0
+
+    metrics_by_run = OrderedDict()
+    heading_row = []
+    base_svr_value = None   # baseline server-throughput
+    base_cli_value = None   # baseline client-throughput
+
+    with open(perf_file, 'rt', encoding="utf-8") as file:
+        for line in file:
+            if lctr == 0:
+
+                (nclients_field, nops_field, svr_metric, cli_metric) = parse_perf_line_names(line)
+                heading_row = [ 'Run-Type', svr_metric, cli_metric ]
+
+            (run_type, svr_value, svr_str, cli_value, cli_str) = \
+                parse_perf_line_values(line)
+
+            if run_type.startswith('Baseline'):
+                base_svr_value = svr_value
+                base_cli_value = cli_value
+
+            metrics_by_run[run_type] = [svr_value, cli_value, svr_str, cli_str ]
+
+            lctr += 1
+
+    # DEBUG: pr_metrics(metrics_by_run)
+
+    if base_svr_value is None or base_cli_value is None:
+        print("Error: Throughputs metrics for baseline run are not known.")
+        sys.exit(1)
+
+    print(f"    **** Performance comparison for {nclients_field}, {nops_field} ****")
+    gen_perf_report(heading_row, metrics_by_run, base_svr_value, base_cli_value)
+
+# #############################################################################
+def parse_perf_line_names(line:str) -> tuple:
+    """
+    Parse a one-line summary line and return a tuple of common, useful, field-names.
+
+    Returns: A tuple; see below.
+        nclients_field  : str   : 'NumClients=5'
+        nops_field      : str   : 'NumOps=5000000 (5 Million)'
+        svr_metric      : str   : 'Server throughput'
+        cli_metric      : str   : 'Client throughput'
+    """
+
+    # pylint: disable-next=unused-variable,line-too-long
+    (run_type_unused, nclients_field, nops_field, svr_field, cli_field, time_unused) = line.split(',')
+
+    nclients_field = nclients_field.lstrip().rstrip()
+    nops_field = nops_field.lstrip().rstrip()
+
+    svr_field = svr_field.lstrip().rstrip()
+
+    # pylint: disable-next=unused-variable
+    (svr_metric, unused) = svr_field.split('=')
+
+    cli_field = cli_field.lstrip().rstrip()
+    (cli_metric, unused) = cli_field.split('=')
+
+    return (nclients_field, nops_field, svr_metric, cli_metric)
+
+# #############################################################################
+def parse_perf_line_values(line:str) -> tuple:
+    """
+    Parse a one-line summary line and return a tuple of useful values.
+    Returns: A tuple; see below.
+        run_type    : str   : 'Baseline - No logging'
+        svr_value   : int   : 91795
+        svr_str     : str   : '(~91.79 K) ops/sec'
+        cli_value   : int   : 20938
+        cli_str     : str   : '(~20.93 K) ops/sec'
+    """
+    # pylint: disable-next=unused-variable
+    (run_type, ct_unused, nops_field, svr_field, cli_field, time_field_unused) = line.split(',')
+    run_type = run_type.lstrip().rstrip()
+
+    (svr_value_str, svr_str) = split_field_value_str(svr_field)
+    (cli_value_str, cli_str) = split_field_value_str(cli_field)
+
+    svr_value = int(svr_value_str)
+    cli_value = int(cli_value_str)
+
+    return (run_type, svr_value, svr_str, cli_value, cli_str)
+
+
+# #############################################################################
+def split_field_value_str(metric_field:str) -> (int, str):
+    """
+    Specialized string-'split' method.
+    Common case:
+      Input:  'Server throughput=53856 (~53.85 K) ops/sec'
+      Returns:    (53856, ~53.85 K ops/sec')
+
+    Lapsed case:
+      Input:  'Server throughput=989 () ops/sec'
+      Returns:    (53856, 989 ops/sec')
+    """
+
+    metric_field = metric_field.lstrip().rstrip()
+    # pylint: disable-next=unused-variable
+    (svr_metric_name_unused, rest) = metric_field.split('=')
+
+    svr_value_str = rest.split(' ')[0]
+    svr_value = int(svr_value_str)
+    svr_str = None
+    if len(rest.split(' ')) > 1:
+        # Will resolve to one of: '~53.85 K) ops/sec' or ') ops/sec'
+        svr_str = rest.split('(')[1]
+        svr_str = svr_str.lstrip().rstrip()
+
+        # Lapsed case: If unit-specifier value in '()' is empty, use the
+        # metric's value as the output. Here return '989 ops/sec'
+        if svr_str.startswith(')'):
+            svr_str = svr_value_str + svr_str.replace(')', '')
+        else:
+            svr_str = svr_str.replace(')', '')
+
+    return (svr_value, svr_str)
+
+# #############################################################################
+def gen_perf_report(heading:list, metrics:dict, base_svr_value:int, base_cli_value:int):
+    """
+    Given a dictionary of metrics, ordered by run-type 'key', generate the
+    comparative performance reports.
+    Ref: https://www.geeksforgeeks.org/how-to-make-a-table-in-python/
+    """
+    perf_table = PrettyTable([heading[0], heading[1], "S:%-Drop", heading[2], "C:%-Drop"])
+
+    for run_type in metrics.keys():
+        svr_value = metrics[run_type][0]
+        cli_value = metrics[run_type][1]
+        svr_str   = metrics[run_type][2]
+        cli_str   = metrics[run_type][3]
+        perf_table.add_row([  run_type
+                            , svr_str, compute_pct_drop(base_svr_value, svr_value)
+                            , cli_str, compute_pct_drop(base_cli_value, cli_value)])
+
+    print(perf_table)
+
+# #############################################################################
+def compute_pct_drop(baseval:int, metric:int) -> float:
+    """
+    Compute the %age drop of new metric v/s baseline value 'baseval'.
+    Returns: Percentage drop as an int
+    """
+    return round((((metric - baseval) / baseval) * 100.0), 2)
+
+# #############################################################################
+def perf_parse_args(args:list):
+    """
+    Parse command-line arguments. Return parsed-arguments object
+    """
+    # ---------------------------------------------------------------
+    # Start of argument parser, with inline examples text
+    # Create 'parser' as object of type ArgumentParser
+    # ---------------------------------------------------------------
+    parser  = argparse.ArgumentParser(description='Generate summary performance'
+                                                 + ' report',
+                                      formatter_class=argparse.RawDescriptionHelpFormatter,
+                                      epilog=r'''Examples:
+
+- Basic usage:
+    ''' + sys.argv[0]
+        + ''' --file <run-all-client-server-perf-tests-file>
+''')
+
+    # ======================================================================
+    # Define required arguments supported by this script
+    parser.add_argument('--file', dest='file'
+                        , metavar='<perf-outfile-name>'
+                        , required=True
+                        , help='Perf test-run output file name')
+
+    parsed_args = parser.parse_args(args)
+    if parsed_args is False:
+        parser.print_help()
+
+    return parsed_args
+
+# #############################################################################
+def pr_metrics(tdict:dict):
+    """
+    Print an ordered dictionary, where value is a tuple.
+    """
+    for key in tdict.keys():
+        print(f"{key=}, value = {tdict[key]}")
+
+###############################################################################
+# Start of the script: Execute only if run as a script
+###############################################################################
+if __name__ == "__main__":
+    main()

--- a/test.sh
+++ b/test.sh
@@ -397,6 +397,13 @@ function build-and-run-sample-c-appln-with-LOC-encoding()
 # #############################################################################
 function run-all-client-server-perf-tests()
 {
+    set +x
+    if [ "${UNAME_S}" = "Darwin" ]; then
+        echo "${Me}: Client-server performance tests not supported currently on Mac/OSX."
+        return
+    fi
+
+    set -x
     # Reset global if arg-1 provided. Minions will grab it from there.
     if [ $# -ge 1 ]; then
         SvrClockArg=$1
@@ -432,7 +439,9 @@ function run-all-client-server-perf-tests()
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
 
     echo " "
+    set -x
     ./scripts/perf_report.py --file "${outfile}"
+    set +x
 
     local total_seconds=$((SECONDS - start_seconds))
     el_h=$((total_seconds / 3600))

--- a/tests/pytests/perf_report_test.py
+++ b/tests/pytests/perf_report_test.py
@@ -1,0 +1,115 @@
+# #############################################################################
+# perf_report_test.py
+#
+"""
+Small set of unit tests to verify output from parsing helper-methods that feed-into
+perf_report_test.py, to generate the performance comparison report.
+"""
+import os
+import sys
+
+# #############################################################################
+# Setup some variables pointing to diff dir/sub-dir full-paths.
+# Dir-tree:
+#  /tests/pytests/
+#   - <this-file>
+# Full dir-path where this tests/  dir lives
+L3PytestsDir    = os.path.realpath(os.path.dirname(__file__))
+L3RootDir       = os.path.realpath(L3PytestsDir + '/../..')
+L3ScriptsDir    = L3RootDir + '/scripts/'
+
+sys.path.append(L3ScriptsDir)
+
+# pylint: disable-msg=import-error,wrong-import-position
+import perf_report
+
+# Canonical string generated from perf u-benchmarking scripts, used
+# to test out parsing methods.
+# pylint: disable=line-too-long
+MSG1 = 'Baseline - No logging, NumClients=5, NumOps=5000000 (5 Million), Server throughput=91795 (~91.79 K) ops/sec, Client throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 (~54.46 Billion) ns'
+
+# String to test parsing out for a line with same format but different field-names
+# pylint: disable=line-too-long
+MSG2 = 'Field is unrelated to parsing, Number-of-Xacts=5, Number-of-Conns=998877 (some-text ), Metric-1 name=98602 (~98.60 K) ops/sec, Metric-2 name throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 ns'
+
+# Strings to test out parsing done by split_field_value_str()
+FIELD1 = 'Server throughput=53856 (~53.85 K) ops/sec'
+FIELD2 = 'Server throughput=989 () ops/sec'
+
+# #############################################################################
+# To see output from test-cases run:
+# $ pytest --capture=tee-sys perf_report_test.py -k test_compute_pct_drop
+# #############################################################################
+
+# #############################################################################
+def test_parse_perf_line_names():
+    """Verify parsing and output from parse_perf_line_names()"""
+
+    (nclients_field, nops_field, svr_metric, cli_metric) = perf_report.parse_perf_line_names(MSG1)
+
+    assert nclients_field == 'NumClients=5'
+    assert nops_field == 'NumOps=5000000 (5 Million)'
+    assert svr_metric == 'Server throughput'
+    assert cli_metric == 'Client throughput'
+
+    (nclients_field, nops_field, svr_metric, cli_metric) = perf_report.parse_perf_line_names(MSG2)
+
+    assert nclients_field == 'Number-of-Xacts=5'
+    assert nops_field == 'Number-of-Conns=998877 (some-text )'
+    assert svr_metric == 'Metric-1 name'
+    assert cli_metric == 'Metric-2 name throughput'
+
+# #############################################################################
+def test_parse_perf_line_values():
+    """Verify parsing and output from parse_perf_line_values()"""
+
+    (run_type, svr_value, svr_str, cli_value, cli_str) = perf_report.parse_perf_line_values(MSG1)
+
+    assert run_type == 'Baseline - No logging'
+    assert svr_value == 91795
+    assert svr_str == '~91.79 K ops/sec'
+    assert cli_value == 20938
+    assert cli_str == '~20.93 K ops/sec'
+
+    (run_type, svr_value, svr_str, cli_value, cli_str) = perf_report.parse_perf_line_values(MSG2)
+
+    assert run_type == 'Field is unrelated to parsing'
+    assert svr_value == 98602
+    assert svr_str == '~98.60 K ops/sec'
+    assert cli_value == 20938
+    assert cli_str == '~20.93 K ops/sec'
+
+# #############################################################################
+def test_split_field_value_str():
+    """Verify parsing and output from split_field_value_str()"""
+
+    (f_value, f_str) = perf_report.split_field_value_str(FIELD1)
+    assert f_value == 53856
+    assert f_str == '~53.85 K ops/sec'
+
+    (f_value, f_str) = perf_report.split_field_value_str(FIELD2)
+    assert f_value == 989
+    assert f_str == '989 ops/sec'
+
+
+# #############################################################################
+def test_compute_pct_drop():
+    """
+    Verify %age-drop computed by compute_pct_drop(). Hopefully, the values
+    chosen and returned %-age drops won't vary on diff test machines due to
+    float-computation precision.
+    """
+
+    pct_float = perf_report.compute_pct_drop(100, 105)
+    assert pct_float == 5.0
+
+    baseval = 100000
+    newval = 100000 + 230
+    pct_float = perf_report.compute_pct_drop(baseval, newval)
+    assert pct_float == 0.23
+
+    one_k = 1000
+    baseval = 91.79 * one_k
+    newval = 101.81 * one_k
+    pct_float = perf_report.compute_pct_drop(baseval, newval)
+    assert pct_float == 10.92


### PR DESCRIPTION
This commit adds `scripts/perf_report.py`, which will generate a performance comparison summary report each time we run `./test.sh` to exercise the `run-all-client-server-perf-tests()` test-method.

- Change server-code slightly to generate a one-line summary in a canonical format. This is done under new `--perf-outfile` cmdline flag, and invoked by `./test.sh for run-all-client-server-perf-tests` method. (Manual execution of server program or executing other test-methods will -not- trigger this one-line summary output.)

- Add `scripts/perf_report.py` - parses the one-line summary generated in the file output under --perf-outfile flag, to generate the performance comparison report.

- Add `tests/pytests/perf_report_test.py`, to verify parsing logic.
- `test.sh`: Cleanup messages. Add execn-timing metrics.

There is a bit of 'handshake' between the one-line summary line generated by the server program, which is parsed by the perf_report.py script. This summary-line format handshake is verified by test-methods in the newly added perf_report_test.py pytest.

### Sample output:

As generated by the execution of `./test.sh run-all-client-server-perf-tests` in CI Linux jobs:

```
   **** Performance comparison for NumClients=5, NumOps=5000 (5 K) ****
+--------------------------+-------------------+----------+-------------------+----------+
|         Run-Type         | Server throughput | S:%-Drop | Client throughput | C:%-Drop |
+--------------------------+-------------------+----------+-------------------+----------+
|  Baseline - No logging   |    993 ops/sec    |   0.0    |  ~39.16 K ops/sec |   0.0    |
|   L3-logging (no LOC)    |    994 ops/sec    |   0.1    |  ~40.67 K ops/sec |   3.84   |
| L3-fast logging (no LOC) |    993 ops/sec    |   0.0    |  ~38.18 K ops/sec |  -2.51   |
|  L3-logging default LOC  |    993 ops/sec    |   0.0    |  ~38.94 K ops/sec |  -0.57   |
|    L3-logging LOC-ELF    |    994 ops/sec    |   0.1    |  ~41.19 K ops/sec |   5.18   |
+--------------------------+-------------------+----------+-------------------+----------+

```

### Timing messages added to test.sh

Show these output lines when running `run-all-client-server-perf-tests` in CI:

```
test.sh: Mon May 27 11:40:18 PDT 2024 Executing run-all-client-server-perf-tests ...

test.sh: Mon May 27 11:40:48 PDT 2024 Completed all client(s)-server communication test [ 0h 0m 30s ].
```