### PR TITLE
[Perf] Enhance formatting of fields in perf report

### DIFF
--- a/scripts/perf_report.py
+++ b/scripts/perf_report.py
@@ -167,8 +167,11 @@ def gen_perf_report(heading:list, metrics:dict, base_svr_value:int, base_cli_val
     Given a dictionary of metrics, ordered by run-type 'key', generate the
     comparative performance reports.
     Ref: https://www.geeksforgeeks.org/how-to-make-a-table-in-python/
+         https://ptable.readthedocs.io/en/latest/tutorial.html
     """
-    perf_table = PrettyTable([heading[0], heading[1], "S:%-Drop", heading[2], "C:%-Drop"])
+    srv_head = 'Srv:Drop'
+    cli_head = 'Cli:Drop'
+    perf_table = PrettyTable([heading[0], heading[1], srv_head, heading[2], cli_head])
 
     for run_type in metrics.keys():
         svr_value = metrics[run_type][0]
@@ -178,6 +181,10 @@ def gen_perf_report(heading:list, metrics:dict, base_svr_value:int, base_cli_val
         perf_table.add_row([  run_type
                             , svr_str, compute_pct_drop(base_svr_value, svr_value)
                             , cli_str, compute_pct_drop(base_cli_value, cli_value)])
+
+    perf_table.align[heading[0]] = "l"
+    perf_table.custom_format[srv_head] = lambda f, v: f"{ v:.2f} %"
+    perf_table.custom_format[cli_head] = lambda f, v: f"{ v:.2f} %"
 
     print(perf_table)
 


### PR DESCRIPTION
This commit applies few PrettyTable() formatting directives to improve the readability and formatting of few columns in the perf-report.

Prior to this fix, the report would look like:

```
agurajada-Linux-Vm:[600] $ ./scripts/perf_report.py \
                 --file /tmp/test.sh.run-all-client-server-perf-tests.out

    **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+--------------------------+-------------------+----------+-------------------+----------+
|         Run-Type         | Server throughput | S:%-Drop | Client throughput | C:%-Drop |
+--------------------------+-------------------+----------+-------------------+----------+
|  Baseline - No logging   | ~100.14 K ops/sec |   0.0    |  ~22.91 K ops/sec |   0.0    |
|   L3-logging (no LOC)    |  ~99.77 K ops/sec |  -0.36   |  ~22.69 K ops/sec |  -0.96   |
| L3-fast logging (no LOC) | ~102.04 K ops/sec |   1.89   |  ~24.74 K ops/sec |   7.98   |
|  L3-logging default LOC  |  ~99.12 K ops/sec |  -1.02   |  ~22.46 K ops/sec |   -2.0   |
|    L3-logging LOC-ELF    |  ~95.97 K ops/sec |  -4.16   |  ~22.86 K ops/sec |  -0.23   |
+--------------------------+-------------------+----------+-------------------+----------+
```

Updated report with these changes will look like:
```
    **** Performance comparison for NumClients=5, NumOps=5000000 (5 Million) ****
+--------------------------+-------------------+----------+-------------------+----------+
| Run-Type                 | Server throughput | Srv:Drop | Client throughput | Cli:Drop |
+--------------------------+-------------------+----------+-------------------+----------+
| Baseline - No logging    | ~100.14 K ops/sec |  0.00 %  |  ~22.91 K ops/sec |  0.00 %  |
| L3-logging (no LOC)      |  ~99.77 K ops/sec | -0.36 %  |  ~22.69 K ops/sec | -0.96 %  |
| L3-fast logging (no LOC) | ~102.04 K ops/sec |  1.89 %  |  ~24.74 K ops/sec |  7.98 %  |
| L3-logging default LOC   |  ~99.12 K ops/sec | -1.02 %  |  ~22.46 K ops/sec | -2.00 %  |
| L3-logging LOC-ELF       |  ~95.97 K ops/sec | -4.16 %  |  ~22.86 K ops/sec | -0.23 %  |
+--------------------------+-------------------+----------+-------------------+----------+
```

Note:
 - Run-type is left-aligned.
 - %age-drop value is properly justified, with '%' units-specifier.