### PR TITLE
Cleanup: Update msgs to report 'counter'. Rework Mac/OSX restrictions.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -458,12 +458,6 @@ function run-all-client-server-perf-tests()
 # #############################################################################
 function test-build-and-run-client-server-perf-test()
 {
-    set +x
-    if [ "${UNAME_S}" = "Darwin" ]; then
-        echo "${Me}: Client-server performance tests not supported currently on Mac/OSX."
-        return
-    fi
-
     local num_msgs_per_client=${NumMsgsPerClient}
     if [ $# -ge 1 ]; then
         num_msgs_per_client=$1
@@ -489,17 +483,20 @@ function test-build-and-run-client-server-perf-test()
     build-and-run-client-server-perf-test "${num_msgs_per_client}" \
                                           "${l3_log_enabled}"
 
-    local nentries=100
-    echo " "
-    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
-    echo " "
+    # Perf-tests are only executed on Linux. So, skip L3-dump for non-Linux p/fs.
+    if [ "${UNAME_S}" == "Linux" ]; then
+        local nentries=100
+        echo " "
+        echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+        echo " "
 
-    set -x
-    # No LOC-encoding is in-effect, so no need for the --loc-binary argument.
-    ./l3_dump.py                                                                \
-            --log-file /tmp/l3.c-server-test.dat                                \
-            --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
-        | tail -${nentries}
+        set -x
+        # No LOC-encoding is in-effect, so no need for the --loc-binary argument.
+        ./l3_dump.py                                                                \
+                --log-file /tmp/l3.c-server-test.dat                                \
+                --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
+            | tail -${nentries}
+    fi
 
     echo " "
     echo "${Me}: Client-server performance testing with L3-fast-logging ON ${SvrClockArg}:"
@@ -509,17 +506,20 @@ function test-build-and-run-client-server-perf-test()
                                           "${l3_LOC_disabled}"      \
                                           "fast"
 
-    local nentries=100
-    echo " "
-    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
-    echo " "
+    # Perf-tests are only executed on Linux. So, skip L3-dump for non-Linux p/fs.
+    if [ "${UNAME_S}" == "Linux" ]; then
+        local nentries=100
+        echo " "
+        echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+        echo " "
 
-    set -x
-    # No LOC-encoding is in-effect, so no need for the --loc-binary argument.
-    ./l3_dump.py                                                                \
-            --log-file /tmp/l3.c-server-test.dat                                \
-            --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
-        | tail -${nentries}
+        set -x
+        # No LOC-encoding is in-effect, so no need for the --loc-binary argument.
+        ./l3_dump.py                                                                \
+                --log-file /tmp/l3.c-server-test.dat                                \
+                --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
+            | tail -${nentries}
+    fi
 
     set +x
     local server_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_server"
@@ -536,12 +536,6 @@ function test-build-and-run-client-server-perf-test()
 # #############################################################################
 function test-build-and-run-client-server-perf-test-l3_loc_eq_1()
 {
-    set +x
-    if [ "${UNAME_S}" = "Darwin" ]; then
-        echo "${Me}: Client-server performance tests not supported currently on Mac/OSX."
-        return
-    fi
-
     local num_msgs_per_client=${NumMsgsPerClient}
     if [ $# -ge 1 ]; then
         num_msgs_per_client=$1
@@ -561,16 +555,19 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_1()
                                           "${l3_log_enabled}"       \
                                           "${l3_LOC_enabled}"
 
-    local nentries=100
-    echo " "
-    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
-    echo " "
-    set -x
-    L3_LOC_ENABLED=1 ./l3_dump.py                                                           \
-                        --log-file /tmp/l3.c-server-test.dat                                \
-                        --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
-                        --loc-binary "./build/${Build_mode}/bin/use-cases/client-server-msgs-perf_loc" \
-                | tail -${nentries}
+    # Perf-tests are only executed on Linux. So, skip L3-dump for non-Linux p/fs.
+    if [ "${UNAME_S}" == "Linux" ]; then
+        local nentries=100
+        echo " "
+        echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+        echo " "
+        set -x
+        L3_LOC_ENABLED=1 ./l3_dump.py                                   \
+                            --log-file /tmp/l3.c-server-test.dat        \
+                            --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
+                            --loc-binary "./build/${Build_mode}/bin/use-cases/client-server-msgs-perf_loc" \
+                    | tail -${nentries}
+    fi
 
     set +x
 }
@@ -581,12 +578,6 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_1()
 # #############################################################################
 function test-build-and-run-client-server-perf-test-l3_loc_eq_2()
 {
-    set +x
-    if [ "${UNAME_S}" = "Darwin" ]; then
-        echo "${Me}: Client-server performance tests not supported currently on Mac/OSX."
-        return
-    fi
-
     local num_msgs_per_client=${NumMsgsPerClient}
     if [ $# -ge 1 ]; then
         num_msgs_per_client=$1
@@ -606,17 +597,20 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_2()
                                           "${l3_log_enabled}"       \
                                           "${l3_LOC_enabled}"
 
-    local nentries=100
-    echo " "
-    echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
-    echo " "
+    # Perf-tests are only executed on Linux. So, skip L3-dump for non-Linux p/fs.
+    if [ "${UNAME_S}" == "Linux" ]; then
+        local nentries=100
+        echo " "
+        echo "${Me}: Run L3-dump script to unpack log-entries. (Last ${nentries} entries.)"
+        echo " "
 
-    # Currently, we are not unpacking LOC-ELF-IDs, so, for dumping this kind
-    # of logging, we don't need the --loc-binary argument.
-    L3_LOC_ENABLED=2 ./l3_dump.py                                                           \
-                        --log-file /tmp/l3.c-server-test.dat                                \
-                        --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
-                | tail -${nentries}
+        # Currently, we are not unpacking LOC-ELF-IDs, so, for dumping this kind
+        # of logging, we don't need the --loc-binary argument.
+        L3_LOC_ENABLED=2 ./l3_dump.py                                   \
+                            --log-file /tmp/l3.c-server-test.dat        \
+                            --binary "./build/${Build_mode}/bin/use-cases/svmsg_file_server"    \
+                    | tail -${nentries}
+    fi
 }
 
 # #############################################################################
@@ -677,6 +671,12 @@ function build-and-run-client-server-perf-test()
                 exit 1
                 ;;
         esac
+    fi
+
+    set +x
+    if [ "${UNAME_S}" = "Darwin" ]; then
+        echo "${Me}: Execution of client-server performance tests not supported currently on Mac/OSX."
+        return
     fi
 
     set +x
@@ -822,38 +822,3 @@ fi
 
 test_all ""
 exit 0
-
-# Currently, this is a simplistic driver, just executing basic `make` commands
-# to ensure that all code / tools build correctly in release mode.
-
-echo " "
-echo "${Me}: Run build-and-test for core L3 package and tests"
-echo " "
-set -x
-make clean && CC=gcc LD=g++ make all-c-tests
-make run-c-tests
-
-make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cpp-tests
-make run-cpp-tests
-
-make clean-l3 && CC=g++ CXX=g++ LD=g++ make all-cc-tests
-make run-cc-tests
-
-# Do it all test execution.
-make clean && CC=g++ CXX=g++ LD=g++ make all
-make run-tests
-
-echo " "
-echo "${Me}: Run build-and-test for core L3 integration with LOC package and tests"
-echo " "
-set -x
-make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1 make all-c-tests
-L3_LOC_ENABLED=1 make run-c-tests
-
-test_l3_dump_py_missing_loc_decoder
-
-make clean-l3 && CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make all-cpp-tests
-L3_LOC_ENABLED=1 make run-cpp-tests
-
-make clean-l3 && CC=g++ CXX=g++ LD=g++ L3_LOC_ENABLED=1 make all-cc-tests
-L3_LOC_ENABLED=1 make run-cc-tests

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -314,12 +314,11 @@ main(int argc, char *argv[])
 
             // Record new-counter value, to show that something can be logged.
 #  if L3_FASTLOG_ENABLED
-            l3_log_fast("Server msg: Increment: ClientID=%d, "
-                        "Elapsed time=%" PRIu64 " ns. (L3-fast-log)",
+            l3_log_fast("Server msg: Increment: ClientID=%d, Counter=%" PRIu64
+                        ". (L3-fast-log)",
                         resp.clientId, resp.counter);
 #  else
-            l3_log("Server msg: Increment: ClientID=%d, "
-                   "Elapsed time=%" PRIu64 " ns.",
+            l3_log("Server msg: Increment: ClientID=%d, Counter=%" PRIu64 ".",
                    resp.clientId, resp.counter);
 #  endif
 
@@ -620,8 +619,8 @@ printSummaryStats(const char *outfile, const char *run_descr,
     size_t cli_throughput = (sum_throughput / num_clients);
 
     printf("For %u clients, %s, num_ops=%lu (%s) ops"
-           ", Elapsed time=%lu (%s) ns"
-           ", Avg. %s time=%lu ns/msg"
+           ", Elapsed time=%" PRIu64 " (%s) ns"
+           ", Avg. %s time=%" PRIu64 " ns/msg"
            ", Server throughput=%lu (%s) ops/sec"
            ", Client throughput=%lu (%s) ops/sec"
            "\n",
@@ -640,10 +639,10 @@ printSummaryStats(const char *outfile, const char *run_descr,
                    outfile);
             exit(EXIT_FAILURE);
         }
-        fprintf(fh, "%s, NumClients=%u, NumOps=%" PRIu64 " (%s)"
+        fprintf(fh, "%s, NumClients=%u, NumOps=%lu (%s)"
                     ", Server throughput=%lu (%s) ops/sec"
                     ", Client throughput=%lu (%s) ops/sec"
-                    ", elapsed_ns=%lu (%s) ns\n",
+                    ", elapsed_ns=%" PRIu64 " (%s) ns\n",
                 run_descr, num_clients, num_ops, value_str(num_ops),
                 svr_throughput, value_str(svr_throughput),
                 cli_throughput, value_str(cli_throughput),


### PR DESCRIPTION
This commit does some low-impact cleanup of client-server perf-tests

- `test.sh`: Currently, these tests were restricted for use on Mac/OSX. However, there are compilation errors in client-server sources on this platform. Rework the restrictions such that all test-methods do perform the build (`make`) step, but skip the execution step. This caught few compilation errors that show up only on Mac/OSX.
-  Delete obsolete test-execution code from test.sh, replaced by named test-methods.

- Fix l3_log() msgs to say 'Counter' rather than 'Elapsed time' as, due to changes done under SHA 2d6b9d6, we are no longer tracking and logging the elapsed-time of each msg implemented.