### PR TITLE
[Perf] Support L3_LOGT_FPRINTF -> l3_log_fprintf() for benchmarking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ help::
 	@echo ' '
 	@echo 'To build client-server performance test programs and run performance test(s)'
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
@@ -572,11 +573,17 @@ ifeq ($(L3_ENABLED), $(L3_DEFAULT))
 
 # Under L3-logging, invoke the L3-fast logging API, which needs the .S file
 ifeq ($(L3_FASTLOG_ENABLED), 1)
+
     CLIENT_SERVER_NON_MAIN_SRCS += $(L3_ASSEMBLY)
     CFLAGS += -DL3_FASTLOG_ENABLED
-endif
+
+else ifeq ($(L3_LOGT_FPRINTF), 1)
+
+    CFLAGS += -DL3_LOGT_FPRINTF
 
 endif
+
+endif   # L3_ENABLED
 
 # Name of LOC-generated source file for the client-server perf-test program.
 ifeq ($(L3_LOC_ENABLED), $(L3_LOC_DEFAULT))

--- a/src/l3.c
+++ b/src/l3.c
@@ -120,7 +120,25 @@ typedef struct l3_log
     L3_ENTRY        slots[L3_MAX_SLOTS];
 } L3_LOG;
 
-L3_LOG *l3_log; // Also referenced in l3.S for fast-logging.
+#define L3_ARRAY_LEN(arr)   (sizeof(arr) / sizeof(*arr))
+
+/**
+ * Support for different 'logging' types under L3's APIs.
+ */
+static const char * L3_logtype_name[] = {
+                          "L3_LOG_unknown"
+                        , "L3_LOG_MMAP"
+                        , "L3_LOG_FPRINTF"
+                };
+
+L3_STATIC_ASSERT((L3_ARRAY_LEN(L3_logtype_name) == L3_LOGTYPE_MAX),
+                  "Incorrect size of array L3_logtype_name[]");
+
+
+L3_LOG *l3_log = NULL;      // L3_LOG_MMAP: Also referenced in l3.S for
+                            // fast-logging.
+
+FILE *  l3_log_fh = NULL;  // L3_LOG_FPRINTF: Opened by fopen()
 
 /**
  * The L3-dump script expects a specific layout and its parsing routines
@@ -128,9 +146,16 @@ L3_LOG *l3_log; // Also referenced in l3.S for fast-logging.
  * L3_LOG{} and L3_ENTRY{}'s size is somewhat of a convenience. They just
  * happen to be of the same size, as of now, hence, this reuse.)
  */
-
 L3_STATIC_ASSERT(offsetof(L3_LOG,slots) == sizeof(L3_ENTRY),
                 "Expected layout of L3_LOG{} is != 32 bytes.");
+
+/**
+ * ****************************************************************************
+ * Function Prototypes
+ * ****************************************************************************
+ */
+int l3_init_fprintf(const char *path);
+
 
 #if __APPLE__
 
@@ -164,6 +189,10 @@ l3_log_init(const l3_log_t logtype, const char *path)
     switch (logtype) {
       case L3_LOG_MMAP:         // L3_LOG_DEFAULT:
         rv = l3_init(path);
+        break;
+
+      case L3_LOG_FPRINTF:
+        rv = l3_init_fprintf(path);
         break;
 
       default:
@@ -242,6 +271,29 @@ l3_init(const char *path)
     return 0;
 }
 
+/**
+ * ****************************************************************************
+ * Initialize L3's logging sub-system to use fprintf() to named `path`.
+ */
+int
+l3_init_fprintf(const char *path)
+{
+    if (!path) {
+        fprintf(stderr, "%s: Invalid arg 'path'=%p\n", __func__, path);
+        return -1;
+    }
+
+    l3_log_fh = fopen(path, "w+");
+    if (!l3_log_fh) {
+        fprintf(stderr, "%s: Error opening log-file at '%p'. errno=%d\n",
+                __func__, path, errno);
+        perror("fopen failed");
+        return -1;
+    }
+    printf("Initialized fprintf() logging to '%s'\n", path);
+    return 0;
+}
+
 // ****************************************************************************
 static pid_t
 l3_mytid(void)
@@ -289,6 +341,17 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
     l3_log->slots[idx].msg = msg;
     l3_log->slots[idx].arg1 = arg1;
     l3_log->slots[idx].arg2 = arg2;
+}
+
+/**
+ * l3_logtype_name() - Map log-type ID to its name.
+ */
+const char *
+l3_logtype_name(l3_log_t logtype)
+{
+    return (((logtype < 0) || (logtype >= L3_LOGTYPE_MAX))
+             ? L3_logtype_name[L3_LOG_UNDEF]
+             : L3_logtype_name[logtype]);
 }
 
 /**

--- a/test.sh
+++ b/test.sh
@@ -472,13 +472,13 @@ function test-build-and-run-client-server-perf-test()
     local l3_LOC_disabled=0
 
     echo " "
-    echo "${Me}: Client-server performance testing with L3-logging OFF ${SvrClockArg}:"
+    echo "**** ${Me}: Client-server performance testing with L3-logging OFF ${SvrClockArg}:"
     echo " "
     build-and-run-client-server-perf-test "${num_msgs_per_client}"      \
                                           "${l3_log_disabled}"
 
     echo " "
-    echo "${Me}: Client-server performance testing with L3-logging ON ${SvrClockArg}:"
+    echo "**** ${Me}: Client-server performance testing with L3-logging ON ${SvrClockArg}:"
     echo " "
     build-and-run-client-server-perf-test "${num_msgs_per_client}" \
                                           "${l3_log_enabled}"
@@ -522,6 +522,19 @@ function test-build-and-run-client-server-perf-test()
     fi
 
     set +x
+
+    echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-fprintf logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_disabled}"      \
+                                          "fprintf"
+
+    echo " "
+    echo "**** ${Me}: Completed basic client(s)-server communication test."
+    echo " "
+
     local server_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_server"
     local client_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_client"
 
@@ -627,6 +640,7 @@ function build-and-run-client-server-perf-test()
 {
     local num_msgs_per_client=$1
     local l3_enabled=$2
+
     local l3_loc_enabled=
     if [ $# -ge 3 ]; then
         l3_loc_enabled=$3
@@ -666,6 +680,15 @@ function build-and-run-client-server-perf-test()
                     make client-server-perf-test
                 ;;
 
+            "fprintf")
+                set -x
+                make clean                      \
+                && CC=gcc LD=g++               \
+                    L3_ENABLED=${l3_enabled}    \
+                    BUILD_VERBOSE=1             \
+                    L3_LOGT_FPRINTF=1           \
+                    make client-server-perf-test
+                ;;
             *)
                 echo "${Me}: Unknown L3-logging type '${l3_log_type}'. Exiting."
                 exit 1
@@ -710,6 +733,15 @@ function build-and-run-client-server-perf-test()
     echo " "
     echo "${Me}: $(TZ="America/Los_Angeles" date) Completed basic client(s)-server communication test."
     echo " "
+
+    if [ "${l3_enabled}" = "1" ]; then
+
+        set -x
+
+        du -sh /tmp/l3.c-server-test.dat
+
+        set +x
+    fi
 }
 
 # #############################################################################

--- a/use-cases/client-server-msgs-perf/svmsg_file_client.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_client.c
@@ -105,7 +105,7 @@ main(int argc, char *argv[])
         niters = atoi(argv[1]);
     }
 
-    printf("Client: ID=%d Perform %lu (%s) message-exchanges to"
+    printf("Client ID=%d Perform %lu (%s) message-exchanges to"
            " increment a number"
 #if L3_ENABLED
            ", with L3-logging"

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -210,15 +210,23 @@ main(int argc, char *argv[])
 
     // Initialize L3-Logging
 #if L3_ENABLED
+    char *l3_log_mode = "<unknown>";
     const char *logfile = "/tmp/l3.c-server-test.dat";
-    int e = l3_log_init(L3_LOG_MMAP, logfile);
+    l3_log_t    logtype = L3_LOG_DEFAULT;
+
+#if L3_LOGT_FPRINTF
+    logtype = L3_LOG_FPRINTF;
+#endif
+
+    int e = l3_log_init(logtype, logfile);
     if (e) {
         errExit("l3_log_init");
     }
 
-    char *l3_log_mode = "<unknown>";
 #if L3_FASTLOG_ENABLED
     l3_log_mode = "fast ";
+#elif L3_LOGT_FPRINTF
+    l3_log_mode = "fprintf() ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED


### PR DESCRIPTION
This commit adds support for `L3_LOGT_FPRINTF=1 make client-server-perf-test` to build client-server perf-tests to log using the `fprintf()` system call.

Makefile and #if'def-ed code is added to support fprintf() logging. `l3_log_fprintf()` defined as static inline to avoid fn-call overhead. 

test.sh - Add "fprintf" support to existing test-method.

Fix seg-fault running fprintf() logging in debug mode.