### PR TITLE
[Perf] Support L3_LOGT_WRITE -> l3_log_write() for benchmarking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,7 @@ help::
 	@echo 'To build client-server performance test programs and run performance test(s)'
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() logging'
-	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=2      make client-server-perf-test  # write()-msg logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() msg logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
@@ -603,10 +602,6 @@ else ifeq ($(L3_LOGT_FPRINTF), 1)
 else ifeq ($(L3_LOGT_WRITE), 1)
 
     CFLAGS += -DL3_LOGT_WRITE
-
-else ifeq ($(L3_LOGT_WRITE), 2)
-
-    CFLAGS += -DL3_LOGT_WRITE_MSG
 
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,12 @@ help::
 	@echo 'To build client-server performance test programs and run performance test(s)'
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=2     make client-server-perf-test  # L3+LOC-ELF logging'
+
 	@echo ' '
 	@echo 'To build L3-sample programs with LOC-enabled and run unit-tests:'
 	@echo ' make clean && CC=gcc LD=g++         L3_LOC_ENABLED=1 make all-c-tests   && L3_LOC_ENABLED=1 make run-c-tests'
@@ -580,6 +582,10 @@ ifeq ($(L3_FASTLOG_ENABLED), 1)
 else ifeq ($(L3_LOGT_FPRINTF), 1)
 
     CFLAGS += -DL3_LOGT_FPRINTF
+
+else ifeq ($(L3_LOGT_WRITE), 1)
+
+    CFLAGS += -DL3_LOGT_WRITE
 
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help::
 	@echo ' make clean && CC=gcc LD=g++ L3_ENABLED=0         make client-server-perf-test  # Baseline'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_FPRINTF=1    make client-server-perf-test  # fprintf() logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=1      make client-server-perf-test  # write() logging'
+	@echo ' make clean && CC=gcc LD=g++ L3_LOGT_WRITE=2      make client-server-perf-test  # write()-msg logging'
 	@echo ' make clean && CC=gcc LD=g++                      make client-server-perf-test  # L3-logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_FASTLOG_ENABLED=1 make client-server-perf-test  # L3 Fast logging'
 	@echo ' make clean && CC=gcc LD=g++ L3_LOC_ENABLED=1     make client-server-perf-test  # L3+LOC logging'
@@ -602,6 +603,10 @@ else ifeq ($(L3_LOGT_FPRINTF), 1)
 else ifeq ($(L3_LOGT_WRITE), 1)
 
     CFLAGS += -DL3_LOGT_WRITE
+
+else ifeq ($(L3_LOGT_WRITE), 2)
+
+    CFLAGS += -DL3_LOGT_WRITE_MSG
 
 endif
 

--- a/include/l3.h
+++ b/include/l3.h
@@ -136,10 +136,6 @@ const char *l3_logtype_name(l3_log_t logtype);
 
     #define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)
 
-    #elif defined(L3_LOGT_WRITE_MSG)
-
-    #define l3_log(msg, arg1, arg2) l3_log_write_msg((msg), arg1, arg2)
-
     #else
     #define l3_log(msg, arg1, arg2)                                     \
             l3_log_mmap((msg),                                          \
@@ -185,9 +181,7 @@ l3_log_fprintf(const char *msg, const uint64_t arg1, const uint64_t arg2)
     fprintf(l3_log_fh, msg, arg1, arg2);
 }
 
-void l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2);
-
-void l3_log_write_msg(const char *msg, const uint64_t arg1, const uint64_t arg2);
+void l3_log_write(const char *msgfmt, const uint64_t arg1, const uint64_t arg2);
 
 #ifdef __cplusplus
 }

--- a/include/l3.h
+++ b/include/l3.h
@@ -56,6 +56,7 @@ typedef enum {
     , L3_LOG_MMAP
     , L3_LOG_FPRINTF
     , L3_LOG_WRITE
+    , L3_LOG_WRITE_MSG
     , L3_LOGTYPE_MAX
     , L3_LOG_DEFAULT    = L3_LOG_MMAP
 } l3_log_t;
@@ -134,6 +135,10 @@ const char *l3_logtype_name(l3_log_t logtype);
     #elif defined(L3_LOGT_WRITE)
 
     #define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)
+
+    #elif defined(L3_LOGT_WRITE_MSG)
+
+    #define l3_log(msg, arg1, arg2) l3_log_write_msg((msg), arg1, arg2)
 
     #else
     #define l3_log(msg, arg1, arg2)                                     \

--- a/include/l3.h
+++ b/include/l3.h
@@ -55,6 +55,7 @@ typedef enum {
       L3_LOG_UNDEF      = 0
     , L3_LOG_MMAP
     , L3_LOG_FPRINTF
+    , L3_LOG_WRITE
     , L3_LOGTYPE_MAX
     , L3_LOG_DEFAULT    = L3_LOG_MMAP
 } l3_log_t;
@@ -96,6 +97,10 @@ const char *l3_logtype_name(l3_log_t logtype);
 
     #  define l3_log(msg, arg1, arg2) l3_log_fprintf((msg), arg1, arg2)
 
+    #elif defined(L3_LOGT_WRITE)
+
+    #  define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)
+
     #else
 
     #  define l3_log(msg, arg1, arg2)                                   \
@@ -125,6 +130,10 @@ const char *l3_logtype_name(l3_log_t logtype);
     #if defined(L3_LOGT_FPRINTF)
 
     #define l3_log(msg, arg1, arg2) l3_log_fprintf((msg), arg1, arg2)
+
+    #elif defined(L3_LOGT_WRITE)
+
+    #define l3_log(msg, arg1, arg2) l3_log_write((msg), arg1, arg2)
 
     #else
     #define l3_log(msg, arg1, arg2)                                     \
@@ -170,6 +179,8 @@ l3_log_fprintf(const char *msg, const uint64_t arg1, const uint64_t arg2)
 {
     fprintf(l3_log_fh, msg, arg1, arg2);
 }
+
+void l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2);
 
 #ifdef __cplusplus
 }

--- a/include/l3.h
+++ b/include/l3.h
@@ -182,6 +182,8 @@ l3_log_fprintf(const char *msg, const uint64_t arg1, const uint64_t arg2)
 
 void l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2);
 
+void l3_log_write_msg(const char *msg, const uint64_t arg1, const uint64_t arg2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/l3.c
+++ b/src/l3.c
@@ -379,34 +379,11 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
 
 /**
  * l3_log_write() - 'C' interface to log L3 log-entries using write()
+ * The user's msg is sprintf()'ed using 'msgfmt' format specifiers, requiring
+ * 2 arguments.
  */
 void
-l3_log_write(const char *msg, const uint64_t arg1, const uint64_t arg2)
-{
-    L3_ENTRY le     = {0};
-    L3_ENTRY *lep   = &le;
-
-    lep->tid = l3_mytid();
-
-    lep->msg = msg;
-    lep->arg1 = arg1;
-    lep->arg2 = arg2;
-
-    if (write(l3_log_fd, lep, sizeof(*lep)) != sizeof(*lep)) {
-        fprintf(stderr, "%s(): write() failed. errno=%d\n",
-                __func__, errno);
-        return;
-    }
-    return;
-}
-
-/**
- * l3_log_write_msg() - 'C' interface to log L3 log-entries using write()
- * Similar to l3_log_write(), but the msg is sprintf()'ed using 'msgfmt' format
- * specifiers, requiring 2 arguments.
- */
-void
-l3_log_write_msg(const char *msgfmt, const uint64_t arg1, const uint64_t arg2)
+l3_log_write(const char *msgfmt, const uint64_t arg1, const uint64_t arg2)
 {
     char msgbuf[255];
 

--- a/src/l3.c
+++ b/src/l3.c
@@ -132,6 +132,7 @@ static const char * L3_logtype_name[] = {
                         , "L3_LOG_MMAP"
                         , "L3_LOG_FPRINTF"
                         , "L3_LOG_WRITE"
+                        , "L3_LOG_WRITE_MSG"
                 };
 
 L3_STATIC_ASSERT((L3_ARRAY_LEN(L3_logtype_name) == L3_LOGTYPE_MAX),
@@ -202,6 +203,7 @@ l3_log_init(const l3_log_t logtype, const char *path)
         break;
 
       case L3_LOG_WRITE:
+      case L3_LOG_WRITE_MSG:
         rv = l3_init_write(path);
         break;
 

--- a/test.sh
+++ b/test.sh
@@ -102,6 +102,7 @@ TestList=(
            "test-build-and-run-client-server-perf-test"
            "test-build-and-run-client-server-perf-test-fprintf"
            "test-build-and-run-client-server-perf-test-write"
+           "test-build-and-run-client-server-perf-test-write-msg"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
 
@@ -440,6 +441,8 @@ function run-all-client-server-perf-tests()
 
     test-build-and-run-client-server-perf-test-write "${num_msgs_per_client}"
 
+    test-build-and-run-client-server-perf-test-write-msg "${num_msgs_per_client}"
+
     test-build-and-run-client-server-perf-test-l3_loc_eq_1 "${num_msgs_per_client}"
 
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
@@ -592,6 +595,33 @@ function test-build-and-run-client-server-perf-test-write()
                                            "${l3_log_enabled}"      \
                                            "${l3_LOC_disabled}"     \
                                            "write"
+}
+
+# #############################################################################
+# Test build-and-run of client-server performance test benchmark, using the
+# write()-msg logging interface under L3..
+# #############################################################################
+function test-build-and-run-client-server-perf-test-write-msg()
+{
+    local num_msgs_per_client=${NumMsgsPerClient}
+    if [ $# -ge 1 ]; then
+        num_msgs_per_client=$1
+    fi
+
+    if [ $# -ge 2 ]; then
+        SvrClockArg=$2
+    fi
+
+    local l3_log_enabled=1
+    local l3_LOC_disabled=0
+
+    echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                           "${l3_log_enabled}"      \
+                                           "${l3_LOC_disabled}"     \
+                                           "write-msg"
 }
 
 # #############################################################################
@@ -748,6 +778,16 @@ function build-and-run-client-server-perf-test()
                     L3_ENABLED=${l3_enabled}    \
                     BUILD_VERBOSE=1             \
                     L3_LOGT_WRITE=1             \
+                    make client-server-perf-test
+                ;;
+
+            "write-msg")
+                set -x
+                make clean                      \
+                && CC=gcc LD=g++               \
+                    L3_ENABLED=${l3_enabled}    \
+                    BUILD_VERBOSE=1             \
+                    L3_LOGT_WRITE=2             \
                     make client-server-perf-test
                 ;;
 

--- a/test.sh
+++ b/test.sh
@@ -101,6 +101,7 @@ TestList=(
 
            "test-build-and-run-client-server-perf-test"
            "test-build-and-run-client-server-perf-test-fprintf"
+           "test-build-and-run-client-server-perf-test-write"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
 
@@ -437,6 +438,8 @@ function run-all-client-server-perf-tests()
 
     test-build-and-run-client-server-perf-test-fprintf "${num_msgs_per_client}"
 
+    test-build-and-run-client-server-perf-test-write "${num_msgs_per_client}"
+
     test-build-and-run-client-server-perf-test-l3_loc_eq_1 "${num_msgs_per_client}"
 
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
@@ -526,14 +529,6 @@ function test-build-and-run-client-server-perf-test()
 
     set +x
     echo " "
-    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
-    echo " "
-    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
-                                           "${l3_log_enabled}"      \
-                                           "${l3_LOC_disabled}"     \
-                                           "write"
-
-    echo " "
     echo "**** ${Me}: Completed basic client(s)-server communication test."
     echo " "
 
@@ -570,6 +565,33 @@ function test-build-and-run-client-server-perf-test-fprintf()
                                            "${l3_log_enabled}"      \
                                            "${l3_LOC_disabled}"     \
                                            "fprintf"
+}
+
+# #############################################################################
+# Test build-and-run of client-server performance test benchmark, using the
+# write() logging interface under L3..
+# #############################################################################
+function test-build-and-run-client-server-perf-test-write()
+{
+    local num_msgs_per_client=${NumMsgsPerClient}
+    if [ $# -ge 1 ]; then
+        num_msgs_per_client=$1
+    fi
+
+    if [ $# -ge 2 ]; then
+        SvrClockArg=$2
+    fi
+
+    local l3_log_enabled=1
+    local l3_LOC_disabled=0
+
+    echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                           "${l3_log_enabled}"      \
+                                           "${l3_LOC_disabled}"     \
+                                           "write"
 }
 
 # #############################################################################

--- a/test.sh
+++ b/test.sh
@@ -526,6 +526,14 @@ function test-build-and-run-client-server-perf-test()
 
     set +x
     echo " "
+    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                           "${l3_log_enabled}"      \
+                                           "${l3_LOC_disabled}"     \
+                                           "write"
+
+    echo " "
     echo "**** ${Me}: Completed basic client(s)-server communication test."
     echo " "
 
@@ -710,6 +718,17 @@ function build-and-run-client-server-perf-test()
                     L3_LOGT_FPRINTF=1           \
                     make client-server-perf-test
                 ;;
+
+            "write")
+                set -x
+                make clean                      \
+                && CC=gcc LD=g++               \
+                    L3_ENABLED=${l3_enabled}    \
+                    BUILD_VERBOSE=1             \
+                    L3_LOGT_WRITE=1             \
+                    make client-server-perf-test
+                ;;
+
             *)
                 echo "${Me}: Unknown L3-logging type '${l3_log_type}'. Exiting."
                 exit 1

--- a/test.sh
+++ b/test.sh
@@ -102,7 +102,6 @@ TestList=(
            "test-build-and-run-client-server-perf-test"
            "test-build-and-run-client-server-perf-test-fprintf"
            "test-build-and-run-client-server-perf-test-write"
-           "test-build-and-run-client-server-perf-test-write-msg"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
 
@@ -441,8 +440,6 @@ function run-all-client-server-perf-tests()
 
     test-build-and-run-client-server-perf-test-write "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-write-msg "${num_msgs_per_client}"
-
     test-build-and-run-client-server-perf-test-l3_loc_eq_1 "${num_msgs_per_client}"
 
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
@@ -572,7 +569,7 @@ function test-build-and-run-client-server-perf-test-fprintf()
 
 # #############################################################################
 # Test build-and-run of client-server performance test benchmark, using the
-# write() logging interface under L3..
+# write() msg logging interface under L3.
 # #############################################################################
 function test-build-and-run-client-server-perf-test-write()
 {
@@ -595,33 +592,6 @@ function test-build-and-run-client-server-perf-test-write()
                                            "${l3_log_enabled}"      \
                                            "${l3_LOC_disabled}"     \
                                            "write"
-}
-
-# #############################################################################
-# Test build-and-run of client-server performance test benchmark, using the
-# write()-msg logging interface under L3..
-# #############################################################################
-function test-build-and-run-client-server-perf-test-write-msg()
-{
-    local num_msgs_per_client=${NumMsgsPerClient}
-    if [ $# -ge 1 ]; then
-        num_msgs_per_client=$1
-    fi
-
-    if [ $# -ge 2 ]; then
-        SvrClockArg=$2
-    fi
-
-    local l3_log_enabled=1
-    local l3_LOC_disabled=0
-
-    echo " "
-    echo "**** ${Me}: Client-server performance testing with L3-write logging ON:"
-    echo " "
-    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
-                                           "${l3_log_enabled}"      \
-                                           "${l3_LOC_disabled}"     \
-                                           "write-msg"
 }
 
 # #############################################################################
@@ -778,16 +748,6 @@ function build-and-run-client-server-perf-test()
                     L3_ENABLED=${l3_enabled}    \
                     BUILD_VERBOSE=1             \
                     L3_LOGT_WRITE=1             \
-                    make client-server-perf-test
-                ;;
-
-            "write-msg")
-                set -x
-                make clean                      \
-                && CC=gcc LD=g++               \
-                    L3_ENABLED=${l3_enabled}    \
-                    BUILD_VERBOSE=1             \
-                    L3_LOGT_WRITE=2             \
                     make client-server-perf-test
                 ;;
 

--- a/tests/unit/l3-fprintf-perf-test.c
+++ b/tests/unit/l3-fprintf-perf-test.c
@@ -1,0 +1,92 @@
+/**
+ * *****************************************************************************
+ * \file l3-fprintf-perf-test.c
+ * \author Aditya P. Gurajada
+ * \brief L3: Lightweight Logging Library fprintf() logging APIs Unit-test
+ * \version 0.1
+ * \date 2024-05-29
+ *
+ * \copyright Copyright (c) 2024
+ *
+ * Usage: program-name [ <number-of-million-msgs> ]
+ *  Default, run fprintf()-logging perf-tests on 1 million messages
+ * *****************************************************************************
+ */
+#define _POSIX_C_SOURCE 199309L
+
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "l3.h"
+#include "l3-perf-test.h"
+
+void test_fprintf_logging_perf(int nMil);
+
+/**
+ * *****************************************************************************
+ * The L3 logging-APIs to exercise logging using fprintf() system call are
+ * exercised in this unit-test. As a convenience, we just log a large # of
+ * entries to get a rough measure of logging throughput using this interface.
+ * *****************************************************************************
+ */
+int
+main(const int argc, const char * argv[])
+{
+    int nMil = 1;
+    if (argc > 1) {
+        nMil = atoi(argv[1]);
+    }
+
+    test_fprintf_logging_perf(nMil);
+
+    return 0;
+}
+
+#if L3_LOGT_FPRINTF
+
+void
+test_fprintf_logging_perf(int nMil)
+{
+    // Logging perf benchmarking methods below share this log-file.
+    const char *logfile = "/tmp/l3-fprintf-logging-test.dat";
+    int e = l3_log_init(L3_LOG_FPRINTF, logfile);
+    if (e) {
+        abort();
+    }
+    test_logging_perf("fprintf", nMil, logfile);
+}
+
+#endif  // L3_LOGT_FPRINTF
+
+/**
+ * *****************************************************************************
+ * test_logging_perf() - Common function to log n-msgs and measure perf metrics.
+ * NOTE: This cannot be a shared function in common .c file as the build-time
+ * -D<flag> dictates which version of l3_log() [ write / fprintf ] will be used.
+ * *****************************************************************************
+ */
+void
+test_logging_perf(const char *logtype, int nMil, const char *filename)
+{
+    struct timespec ts0;
+    struct timespec ts1;
+    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
+        abort();
+    }
+
+    uint32_t n = 0;
+    for (n = 0; n < (nMil * L3_MILLION); n++) {
+        l3_log("Perf-l3-log msgs, ctr=%d, value=%d\n", n, 0);
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
+        abort();
+    }
+    uint64_t nsec0 = timespec_to_ns(&ts0);
+    uint64_t nsec1 = timespec_to_ns(&ts1);
+
+    printf("%d Mil %s() log msgs: %" PRIu64 " ns/msg (avg): %s\n",
+            nMil, logtype, ((nsec1 - nsec0) / n), filename);
+}

--- a/tests/unit/l3-perf-test.h
+++ b/tests/unit/l3-perf-test.h
@@ -1,0 +1,29 @@
+/**
+ * *****************************************************************************
+ * \file l3-perf-test.h
+ * \author Aditya P. Gurajada
+ * \brief L3: Lightweight Logging Library performance unit-test header
+ * \version 0.1
+ * \date 2024-05-29
+ *
+ * \copyright Copyright (c) 2024
+ * *****************************************************************************
+ */
+#include <stdio.h>
+#include <time.h>
+#include "l3.h"
+
+// Useful constants
+#define L3_MILLION      ((uint32_t) (1000 * 1000))
+#define L3_NS_IN_SEC    ((uint32_t) (1000 * 1000 * 1000))
+
+ // Function prototypes
+ void test_logging_perf(const char *logtype, int nMil, const char *filename);
+
+// Convert timespec value to nanoseconds units.
+static uint64_t inline
+timespec_to_ns(struct timespec *ts)
+{
+    return ((ts->tv_sec * L3_NS_IN_SEC) + ts->tv_nsec);
+}
+

--- a/tests/unit/l3-write-perf-test.c
+++ b/tests/unit/l3-write-perf-test.c
@@ -1,0 +1,138 @@
+/**
+ * *****************************************************************************
+ * \file l3-write-perf-test.c
+ * \author Aditya P. Gurajada
+ * \brief L3: Lightweight Logging Library write() logging APIs Unit-test
+ * \version 0.1
+ * \date 2024-05-29
+ *
+ * \copyright Copyright (c) 2024
+ *
+ * Usage: program-name [ <number-of-million-msgs> ]
+ *  Default, run write()-logging perf-tests on 1 million messages
+ * *****************************************************************************
+ */
+#define _POSIX_C_SOURCE 199309L
+
+#include <stdlib.h>
+#include <time.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "l3.h"
+#include "l3-perf-test.h"
+
+static void test_write_logging_perf(int nMil);
+static void test_write_msg_logging_perf(int nMil);
+static void test_msg_logging_perf(const char *logtype, int nMil, const char *filename);
+
+/**
+ * *****************************************************************************
+ * The L3 logging-APIs to exercise logging using write() system call are
+ * exercised in this unit-test. As a convenience, we just log a large # of
+ * entries to get a rough measure of logging throughput using this interface.
+ * *****************************************************************************
+ */
+int
+main(const int argc, const char * argv[])
+{
+    int nMil = 1;
+    if (argc > 1) {
+        nMil = atoi(argv[1]);
+    }
+
+    // Warm-up
+    test_write_logging_perf(1);
+
+    test_write_logging_perf(nMil);
+    test_write_msg_logging_perf(nMil);
+
+    return 0;
+}
+
+#if L3_LOGT_WRITE
+static void
+test_write_logging_perf(int nMil)
+{
+    // Logging perf benchmarking methods below share this log-file.
+    const char *logfile = "/tmp/l3-write-logging-test.dat";
+    int e = l3_log_init(L3_LOG_WRITE, logfile);
+    if (e) {
+        abort();
+    }
+    test_logging_perf("write", nMil, logfile);
+}
+
+static void
+test_write_msg_logging_perf(int nMil)
+{
+    // Logging perf benchmarking methods below share this log-file.
+    const char *logfile = "/tmp/l3-writemsg-logging-test.dat";
+    int e = l3_log_init(L3_LOG_WRITE, logfile);
+    if (e) {
+        abort();
+    }
+    test_msg_logging_perf("write", nMil, logfile);
+}
+#endif  // L3_LOGT_WRITE
+
+/**
+ * *****************************************************************************
+ * test_logging_perf() - Common function to log n-msgs and measure perf metrics.
+ * NOTE: This cannot be a shared function in common .c file as the build-time
+ * -D<flag> dictates which version of l3_log() [ write / fprintf ] will be used.
+ * *****************************************************************************
+ */
+void
+test_logging_perf(const char *logtype, int nMil, const char *filename)
+{
+    struct timespec ts0;
+    struct timespec ts1;
+    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
+        abort();
+    }
+
+    uint32_t n = 0;
+    for (n = 0; n < (nMil * L3_MILLION); n++) {
+        l3_log("Perf-l3-log msgs, ctr=%d, value=%d\n", n, 0);
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
+        abort();
+    }
+    uint64_t nsec0 = timespec_to_ns(&ts0);
+    uint64_t nsec1 = timespec_to_ns(&ts1);
+
+    printf("%d Mil %s() log msgs: %" PRIu64 " ns/msg (avg): %s\n",
+            nMil, logtype, ((nsec1 - nsec0) / n), filename);
+}
+
+/**
+ * Identical to shared test_logging_perf() method, but this invokes the
+ * write_msg() interface which will format the message w/ parameters
+ * before logging it.
+ */
+static void
+test_msg_logging_perf(const char *logtype, int nMil, const char *filename)
+{
+    struct timespec ts0;
+    struct timespec ts1;
+    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
+        abort();
+    }
+
+    uint32_t n = 0;
+    for (n = 0; n < (nMil * L3_MILLION); n++) {
+        l3_log_write_msg("Perf-l3-log msgs, ctr=%d, value=%d\n", n, 0);
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
+        abort();
+    }
+    uint64_t nsec0 = timespec_to_ns(&ts0);
+    uint64_t nsec1 = timespec_to_ns(&ts1);
+
+    printf("%d Mil %s() log msgs: %" PRIu64 " ns/msg (avg): %s\n",
+            nMil, logtype, ((nsec1 - nsec0) / n), filename);
+}

--- a/tests/unit/l3-write-perf-test.c
+++ b/tests/unit/l3-write-perf-test.c
@@ -24,8 +24,6 @@
 #include "l3-perf-test.h"
 
 static void test_write_logging_perf(int nMil);
-static void test_write_msg_logging_perf(int nMil);
-static void test_msg_logging_perf(const char *logtype, int nMil, const char *filename);
 
 /**
  * *****************************************************************************
@@ -46,7 +44,6 @@ main(const int argc, const char * argv[])
     test_write_logging_perf(1);
 
     test_write_logging_perf(nMil);
-    test_write_msg_logging_perf(nMil);
 
     return 0;
 }
@@ -64,17 +61,6 @@ test_write_logging_perf(int nMil)
     test_logging_perf("write", nMil, logfile);
 }
 
-static void
-test_write_msg_logging_perf(int nMil)
-{
-    // Logging perf benchmarking methods below share this log-file.
-    const char *logfile = "/tmp/l3-writemsg-logging-test.dat";
-    int e = l3_log_init(L3_LOG_WRITE, logfile);
-    if (e) {
-        abort();
-    }
-    test_msg_logging_perf("write", nMil, logfile);
-}
 #endif  // L3_LOGT_WRITE
 
 /**
@@ -96,35 +82,6 @@ test_logging_perf(const char *logtype, int nMil, const char *filename)
     uint32_t n = 0;
     for (n = 0; n < (nMil * L3_MILLION); n++) {
         l3_log("Perf-l3-log msgs, ctr=%d, value=%d\n", n, 0);
-    }
-
-    if (clock_gettime(CLOCK_REALTIME, &ts1)) {
-        abort();
-    }
-    uint64_t nsec0 = timespec_to_ns(&ts0);
-    uint64_t nsec1 = timespec_to_ns(&ts1);
-
-    printf("%d Mil %s() log msgs: %" PRIu64 " ns/msg (avg): %s\n",
-            nMil, logtype, ((nsec1 - nsec0) / n), filename);
-}
-
-/**
- * Identical to shared test_logging_perf() method, but this invokes the
- * write_msg() interface which will format the message w/ parameters
- * before logging it.
- */
-static void
-test_msg_logging_perf(const char *logtype, int nMil, const char *filename)
-{
-    struct timespec ts0;
-    struct timespec ts1;
-    if (clock_gettime(CLOCK_REALTIME, &ts0)) {
-        abort();
-    }
-
-    uint32_t n = 0;
-    for (n = 0; n < (nMil * L3_MILLION); n++) {
-        l3_log_write_msg("Perf-l3-log msgs, ctr=%d, value=%d\n", n, 0);
     }
 
     if (clock_gettime(CLOCK_REALTIME, &ts1)) {

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -219,6 +219,8 @@ main(int argc, char *argv[])
     logtype = L3_LOG_FPRINTF;
 #elif L3_LOGT_WRITE
     logtype = L3_LOG_WRITE;
+#elif L3_LOGT_WRITE_MSG
+    logtype = L3_LOG_WRITE_MSG;
 #endif
 
     int e = l3_log_init(logtype, logfile);
@@ -232,6 +234,8 @@ main(int argc, char *argv[])
     l3_log_mode = "fprintf() ";
 #elif L3_LOGT_WRITE
     l3_log_mode = "write() ";
+#elif L3_LOGT_WRITE_MSG
+    l3_log_mode = "write()-msg ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -137,6 +137,7 @@ const char * Options_str = "o:dhmprt";
 
 int parse_arguments(const int argc, char *argv[], int *clock_id, char **outfile);
 void print_usage(const char *program, struct option options[]);
+
 void printSummaryStats(const char *outfile, const char *run_descr,
                        Client_info *clients, unsigned int num_clients,
                        int clock_id, uint64_t elapsed_ns);
@@ -216,6 +217,8 @@ main(int argc, char *argv[])
 
 #if L3_LOGT_FPRINTF
     logtype = L3_LOG_FPRINTF;
+#elif L3_LOGT_WRITE
+    logtype = L3_LOG_WRITE;
 #endif
 
     int e = l3_log_init(logtype, logfile);
@@ -227,6 +230,8 @@ main(int argc, char *argv[])
     l3_log_mode = "fast ";
 #elif L3_LOGT_FPRINTF
     l3_log_mode = "fprintf() ";
+#elif L3_LOGT_WRITE
+    l3_log_mode = "write() ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -219,8 +219,6 @@ main(int argc, char *argv[])
     logtype = L3_LOG_FPRINTF;
 #elif L3_LOGT_WRITE
     logtype = L3_LOG_WRITE;
-#elif L3_LOGT_WRITE_MSG
-    logtype = L3_LOG_WRITE_MSG;
 #endif
 
     int e = l3_log_init(logtype, logfile);
@@ -234,8 +232,6 @@ main(int argc, char *argv[])
     l3_log_mode = "fprintf() ";
 #elif L3_LOGT_WRITE
     l3_log_mode = "write() ";
-#elif L3_LOGT_WRITE_MSG
-    l3_log_mode = "write()-msg ";
 #else
     l3_log_mode = "";
 #endif  // L3_FASTLOG_ENABLED
@@ -335,7 +331,7 @@ main(int argc, char *argv[])
                         ". (L3-fast-log)",
                         resp.clientId, resp.counter);
 #  else
-            l3_log("Server msg: Increment: ClientID=%d, Counter=%" PRIu64 ".",
+            l3_log("Server msg: Increment: ClientID=%d, Counter=%" PRIu64 ".\n",
                    resp.clientId, resp.counter);
 #  endif
 


### PR DESCRIPTION
This commit adds support for `L3_LOGT_WRITE=1 make client-server-perf-test` to build client-server perf-tests to log using write() system call.

- Makefile and #if'def-ed code is added to support write() logging.
- test.sh - Add "write" logging-support to existing test-method.

-----

###   [Perf] Add fprintf/write-logging perf unit-tests

This commit adds couple of new unit-tests to do standalone micro-benchmarking of the performance of l3_log_fprintf(),
 vs l3_log_write() interfaces.

- `make run-unit-tests` will automatically invoke these new tests.
- To resolve usefulness of `write()` v/s writing out a formatted a message, this perf unit-test provides an alternate implementation of `write_msg()` interface thru `l3_log()`.
 
Details in the descriptions below.