### PR TITLE
[Spdlog] Add spdlog sample program, Makefile and CI build.yml rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,34 @@ jobs:
             sudo apt-get update -y
             sudo apt-get install -y pylint pip
 
+            # spdlog package needs 'fmt' library as a pre-requisite
+            sudo apt-get install -y libfmt-dev/jammy
+            sudo apt-get install -y libspdlog-dev
+
         elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install python
             brew install pylint
 
             # To install llvm-readelf
             brew install llvm
+
+            # spdlog package needs 'fmt' library as a pre-requisite
+            brew install fmt
+            brew install spdlog
+
+            # Check required spdlog and fmt .h files
+            set -x
+            ls -l /opt/homebrew/include/spdlog
+
+            ls -l /opt/homebrew/include/fmt
+
+            ls -l /usr/local/opt
+
+            ls -l /opt/homebrew/include/spdlog/
+
+            ls -l /opt/homebrew/lib/*spdlog*
+
+            set +x
         fi
 
         pip install pytest
@@ -214,6 +236,10 @@ jobs:
     - name: test-build-and-run-client-server-perf-test-l3_loc_eq_2
       run: |
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_2
+
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-spdlog-sample
+      run: RUN_ON_CI=1 ./test.sh test-build-and-run-spdlog-sample
 
     # -------------------------------------------------------------------------
     # Exercise the do-it-all perf-tests method, which is really intended for

--- a/src/l3.c
+++ b/src/l3.c
@@ -90,14 +90,14 @@ L3_STATIC_ASSERT(sizeof(loc_t) == sizeof(uint32_t),
  * tool / technique can be used to unpack log-entries when dumping the contents
  * of a L3-log file.
  */
-typedef uint8_t platform_t;
+typedef uint8_t platform_u8_t;
 enum platform_t
 {
       L3_LOG_PLATFORM_LINUX             =  ((uint8_t) 1)
     , L3_LOG_PLATFORM_MACOSX            // ((uint8_t) 2)
 };
 
-typedef uint8_t loc_type_t;
+typedef uint8_t loc_type_u8_t;
 enum loc_type_t
 {
       L3_LOG_LOC_NONE                   =  ((uint8_t) 0)

--- a/test.sh
+++ b/test.sh
@@ -107,6 +107,9 @@ TestList=(
 
            "test-pytests"
 
+           # spdlog-related test methods
+           "test-build-and-run-spdlog-sample"
+
            # Keep these two at the end, so that we can exercise this
            # script in CI with the --from-test interface, to run just
            # these two tests.
@@ -814,6 +817,25 @@ function test-pytests()
     pytest -v
 
     popd
+}
+
+# #############################################################################
+# Build-and-run spdlog sample tutorial program. This test-method validates that
+# the required dependencies for using spdlog, integrated with L3, are met.
+# #############################################################################
+function test-build-and-run-spdlog-sample()
+{
+    make clean && CC=g++ LD=g++ BUILD_VERBOSE=1 make spdlog-cpp-program
+
+    local test_prog="./build/${Build_mode}/bin/use-cases/spdlog-Cpp-program"
+
+    set +x
+    echo " "
+    echo "${Me}: Run spdlog sample program ..."
+    echo " "
+
+    set -x
+    ${test_prog}
 }
 
 # #############################################################################

--- a/test.sh
+++ b/test.sh
@@ -104,6 +104,7 @@ TestList=(
            "test-build-and-run-client-server-perf-test-write"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_1"
            "test-build-and-run-client-server-perf-test-l3_loc_eq_2"
+           "test-build-and-run-client-server-perf-test-spdlog"
 
            "test-pytests"
 
@@ -447,6 +448,8 @@ function run-all-client-server-perf-tests()
 
     test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
 
+    test-build-and-run-client-server-perf-test-spdlog "${num_msgs_per_client}"
+
     echo " "
     set -x
     ./scripts/perf_report.py --file "${outfile}"
@@ -681,6 +684,46 @@ function test-build-and-run-client-server-perf-test-l3_loc_eq_2()
 }
 
 # #############################################################################
+# Test build-and-run of client-server performance test benchmark,
+# with C++ spdlog logging.
+# #############################################################################
+function test-build-and-run-client-server-perf-test-spdlog()
+{
+    local num_msgs_per_client=1000
+    if [ $# -eq 1 ]; then
+        num_msgs_per_client=$1
+    fi
+    set +x
+
+    # spdlog is used here only for performance benchmarking.
+    local l3_log_enabled=0
+    local l3_LOC_enabled=0
+
+    echo " "
+    echo "${Me}: Client-server performance testing with spdlog-logging:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_enabled}"       \
+                                          "spdlog"
+
+    # Perf-tests are only executed on Linux. So, skip L3-dump for non-Linux p/fs.
+    if [ "${UNAME_S}" == "Linux" ]; then
+        local nentries=100
+        echo " "
+        tail -${nentries} /tmp/l3.c-server-test.dat
+    fi
+
+    echo " "
+    echo "${Me}: Client-server performance testing with spdlog-backtrace logging:"
+    echo " "
+    build-and-run-client-server-perf-test "${num_msgs_per_client}"  \
+                                          "${l3_log_enabled}"       \
+                                          "${l3_LOC_enabled}"       \
+                                          "spdlog-backtrace"
+}
+
+# #############################################################################
 # Minion to test-build-and-run-client-server-perf-test(), to actually perform
 # the build and run the client/server application for performance benchmarking.
 #
@@ -705,6 +748,7 @@ function build-and-run-client-server-perf-test()
         l3_log_type=$4
     fi
 
+    echo "${Me}: ${num_msgs_per_client}, '${l3_enabled}', '${l3_loc_enabled}', '${l3_log_type}'"
     set +x
     # Makefile does not implement 'run' step. Do it here manually.
     local server_bin="./build/${Build_mode}/bin/use-cases/svmsg_file_server"
@@ -751,6 +795,26 @@ function build-and-run-client-server-perf-test()
                     L3_ENABLED=${l3_enabled}    \
                     BUILD_VERBOSE=1             \
                     L3_LOGT_WRITE=1             \
+                    make client-server-perf-test
+                ;;
+
+            "spdlog")
+                set -x
+                make clean                          \
+                && CC=g++ LD=g++                    \
+                    L3_ENABLED=${l3_enabled}        \
+                    L3_LOGT_SPDLOG=1                \
+                    BUILD_VERBOSE=1                 \
+                    make client-server-perf-test
+                ;;
+
+            "spdlog-backtrace")
+                set -x
+                make clean                          \
+                && CC=g++ LD=g++                    \
+                    L3_ENABLED=${l3_enabled}        \
+                    L3_LOGT_SPDLOG=2                \
+                    BUILD_VERBOSE=1                 \
                     make client-server-perf-test
                 ;;
 

--- a/use-cases/client-server-msgs-perf/ename.c.inc
+++ b/use-cases/client-server-msgs-perf/ename.c.inc
@@ -10,7 +10,7 @@
 
 // Generated file. cp'ed here from `make all` output of the full repo sources.
 
-static char *ename[] = {
+static const char *ename[] = {
     /*   0 */ "",
     /*   1 */ "EPERM", "ENOENT", "ESRCH", "EINTR", "EIO", "ENXIO",
     /*   7 */ "E2BIG", "ENOEXEC", "EBADF", "ECHILD",

--- a/use-cases/client-server-msgs-perf/svmsg_file_server.c
+++ b/use-cases/client-server-msgs-perf/svmsg_file_server.c
@@ -69,6 +69,18 @@ Usage: ./svmsg_file_server --help
 #include <time.h>
 #include <assert.h>
 #include <getopt.h>     // For getopt_long()
+
+#ifdef __cplusplus
+#  if defined(L3_LOGT_SPDLOG) or defined(L3_LOGT_SPDLOG_BACKTRACE)
+
+#   include <iostream>
+#   include "spdlog/spdlog.h"
+#   include "spdlog/sinks/basic_file_sink.h"
+    using namespace std;
+
+#  endif    // L3_LOGT_SPDLOG
+#endif  // __cplusplus
+
 #include "svmsg_file.h"
 #include "l3.h"
 #include "size_str.h"
@@ -209,9 +221,42 @@ main(int argc, char *argv[])
 
     char run_descr[80];
 
+
+    // L3 does not directly support spdlog. Manaage it separately.
+#if defined(L3_LOGT_SPDLOG)
+    // Create basic file logger (not rotated).
+    // string logfile = "/tmp/basic-log.txt";
+    const char *logfile = "/tmp/l3.c-server-test.dat";
+    auto spd_logger = spdlog::basic_logger_mt("file_logger", logfile,
+                                              true);
+    const char *logging_type = "spdlog";
+
+    printf("Start Server, using clock '%s'"
+           ": Initiate spdlog-logging to log-file '%s'"
+           ", using logtype '%s'.\n",
+           clock_name(clock_id), logfile, logging_type);
+
+    snprintf(run_descr, sizeof(run_descr), "%s-logging", logging_type);
+
+#elif defined(L3_LOGT_SPDLOG_BACKTRACE)
+
+    const char *logfile = "/tmp/l3.c-server-test.dat";
+    // Configure same # of backtrace msg-capacity to spdlog as
+    // is being configured for L3's mmap()-ed buffer.
+    spdlog::enable_backtrace(L3_MAX_SLOTS);
+
+    const char *logging_type = "spdlog-backtrace";
+
+    printf("Start Server, using clock '%s'"
+           ": Initiate spdlog-logging (log-file '%s' unused)"
+           ", using logtype '%s'.\n",
+           clock_name(clock_id), logfile, logging_type);
+
+    snprintf(run_descr, sizeof(run_descr), "%s-logging", logging_type);
+
+#elif L3_ENABLED
     // Initialize L3-Logging
-#if L3_ENABLED
-    char *l3_log_mode = "<unknown>";
+    const char *l3_log_mode = "<unknown>";
     const char *logfile = "/tmp/l3.c-server-test.dat";
     l3_log_t    logtype = L3_LOG_DEFAULT;
 
@@ -265,15 +310,19 @@ main(int argc, char *argv[])
 #endif // L3_ENABLED
 
     /* Read requests, handle each in a separate child process */
+    Client_info *clientp = NULL;
     requestMsg req;
     responseMsg resp;
 
     struct timespec ts0 = {0};
     struct timespec ts1 = {0};
+
+#if !defined(__APPLE__)
     if (clock_gettime(clock_id, &ts0)) {    // ***** Timing begins
         errExit("clock_gettime-ts0");
     }
-    Client_info *clientp = NULL;
+#endif  // ! __APPLE__
+
     for (;;) {
 
         msgLen = msgrcv(serverId, &req, REQ_MSG_SIZE, 0, 0);
@@ -285,7 +334,7 @@ main(int argc, char *argv[])
             break;                      /* ... so terminate loop */
         }
 
-        switch (req.mtype) {
+        switch ((int) req.mtype) {
 
           case REQ_MT_INIT:
             resp.mtype = req.mtype;         // Confirm initialization is done
@@ -323,9 +372,20 @@ main(int argc, char *argv[])
             resp.counter = ++clientp->client_ctr;   // Do Increment
             clientp->num_ops++;                     // Track # of operations
 
-#if L3_ENABLED
+            // Record time-consumed. (NOTE: See clarification below.)
+#  if defined(L3_LOGT_SPDLOG)
+            spd_logger->info("Server spdlog: "
+                             "Increment: ClientID={}, Counter{}.",
+                             resp.clientId, resp.counter);
 
-            // Record new-counter value, to show that something can be logged.
+#  elif defined(L3_LOGT_SPDLOG_BACKTRACE)
+
+            spdlog::debug("Server spdlog-Backtrace: "
+                         "Increment: ClientID={}, Counter={}.",
+                         resp.clientId, resp.counter);
+
+#elif L3_ENABLED
+
 #  if L3_FASTLOG_ENABLED
             l3_log_fast("Server msg: Increment: ClientID=%d, Counter=%" PRIu64
                         ". (L3-fast-log)",
@@ -333,7 +393,7 @@ main(int argc, char *argv[])
 #  else
             l3_log("Server msg: Increment: ClientID=%d, Counter=%" PRIu64 ".\n",
                    resp.clientId, resp.counter);
-#  endif
+#  endif    // L3_FASTLOG_ENABLED
 
 #endif // L3_ENABLED
 
@@ -380,11 +440,15 @@ main(int argc, char *argv[])
             }
             break;
 
+#if !defined(__cplusplus)
           case REQ_MT_QUIT:
           default:
             assert(1 == 0);
             break;
+#endif  // __cplusplus
+
         }
+
         // Client may have exited, so no need to send ack-response back to it.
         if (req.clientId && msgsnd(req.clientId, &resp, RESP_MSG_SIZE, 0) == -1) {
             printf("Warning: msgsnd() to client ID=%d failed to deliver.\n",
@@ -396,9 +460,13 @@ main(int argc, char *argv[])
     }
 
 end_forever_loop:
+
+#if !defined(__APPLE__)
     if (clock_gettime(clock_id, &ts1)) {        // **** Timing ends
         errExit("clock_gettime-ts1");
     }
+#endif  // ! __APPLE__
+
     assert(NumActiveClients == 0);
 
     uint64_t nsec0 = timespec_to_ns(&ts0);
@@ -410,8 +478,15 @@ end_forever_loop:
     }
 
     // Close L3-logging upon exit.
-#if L3_ENABLED
+#if defined(L3_LOGT_SPDLOG_BACKTRACE)
+
+    // Log the messages now! show the last n-messages
+    spdlog::dump_backtrace();
+
+#elif L3_ENABLED
+
     l3_log_deinit(logtype);
+
 #endif  // L3_ENABLED
 
     printf("Server: # active clients=%d (HWM=%d). Exiting.\n",
@@ -422,9 +497,20 @@ end_forever_loop:
 
     // For visibility into how clocks are performing on user's machine,
     // run clock-calibration after all workload / metrics collection is done.
+
+#if defined(__cplusplus)
+
+#if !defined(L3_ENABLED) and !defined(L3_LOGT_SPDLOG) and !defined(L3_LOGT_SPDLOG_BACKTRACE)
+    svr_clock_calibrate();
+#endif
+
+#else   // __cplusplus
+
 #if !defined(L3_ENABLED)
     svr_clock_calibrate();
 #endif  // L3_ENABLED
+
+#endif  // __cplusplus
 
     exit(EXIT_SUCCESS);
 }
@@ -531,7 +617,7 @@ svr_clock_calibrate(void)
 
     printf("Calibrate clock overheads over %d (%s) iterations:\n",
            NUM_ITERATIONS, value_str(NUM_ITERATIONS));
-    for (int cctr = 0; cctr < ARRAY_LEN(clockids); cctr++) {
+    for (unsigned cctr = 0; cctr < ARRAY_LEN(clockids); cctr++) {
         clockid_t clockid = clockids[cctr];
 
         struct timespec ts_clock;
@@ -629,7 +715,7 @@ printSummaryStats(const char *outfile, const char *run_descr,
     size_t  num_ops = 0;
     size_t  sum_throughput = 0;
 
-    for (int cctr = 0 ; cctr < num_clients; cctr++) {
+    for (unsigned int cctr = 0 ; cctr < num_clients; cctr++) {
         num_ops += clients[cctr].num_ops;
         sum_throughput += clients[cctr].throughput;
     }

--- a/use-cases/spdlog-Cpp-program/test-main.cpp
+++ b/use-cases/spdlog-Cpp-program/test-main.cpp
@@ -1,0 +1,76 @@
+/**
+ * *****************************************************************************
+ * spdlog-Cpp-program/test-main.cpp: spdlog example program.
+ *
+ * Developed based on docs / examples from spdlog repo
+ * References:
+ *  [1] https://github.com/gabime/spdlog
+ *  [2] https://github.com/gabime/spdlog/blob/v1.x/example/example.cpp
+ *
+ * ---- Build Instructions: ----
+ *
+ * $ sudo apt-get install -y libfmt-dev/jammy   # Pre-requisite 'fmt' library
+ * $ sudo apt-get install -y libspdlog-dev
+ *
+ * $ cd ~/Projects/
+ * $ git clone https://github.com/gabime/spdlog.git
+ * $ cd spdlog && mkdir build && cd build
+ * $ cmake .. && make -j
+ *
+ * Now build this test program using the library built above.
+ * $ g++ -I /usr/include/spdlog -o spdlog-Cpp-program test-main.cpp -L ~/Projects/spdlog/build -l spdlog -l fmt
+ * *****************************************************************************
+ */
+#include <iostream>
+#include "spdlog/spdlog.h"
+
+#include "spdlog/sinks/basic_file_sink.h"
+using namespace std;
+
+void
+basic_example(void)
+{
+    // Create basic file logger (not rotated).
+    string logfile = "/tmp/basic-log.txt";
+    auto my_logger = spdlog::basic_logger_mt("file_logger", logfile, true);
+    my_logger->info("Welcome to spdlog!");
+    my_logger->critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
+    cout << "spdlog messages can be found in '" << logfile << "'\n";
+}
+
+/**
+ * Debug messages can be stored in a ring buffer instead of being logged
+ * immediately. This is useful to display debug logs only when needed
+ * (e.g. when an error happens).
+ * When needed, call dump_backtrace() to dump them to your log.
+ */
+void
+backtrace_example(void)
+{
+    spdlog::enable_backtrace(32); // Store the latest 32 messages in a buffer.
+    // or my_logger->enable_backtrace(32)..
+    for(int i = 0; i < 100; i++)
+    {
+        spdlog::debug("Backtrace message {}", i); // not logged yet..
+    }
+    // e.g. if some error happened:
+    spdlog::dump_backtrace(); // log them now! show the last 32 messages
+    // or my_logger->dump_backtrace(32)..
+}
+
+int
+main()
+{
+    cout << "Hello world\n";
+    spdlog::info("Welcome to spdlog!");
+    spdlog::error("Some error message with arg: {}", 1);
+    spdlog::warn("Easy padding in numbers like {:08d}", 12);
+    spdlog::critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
+    spdlog::info("Support for floats {:03.2f}", 1.23456);
+    spdlog::info("Positional args are {1} {0}..", "too", "supported");
+    spdlog::info("{:<30}", "left aligned");
+
+    backtrace_example();
+
+    basic_example();
+}

--- a/use-cases/utils/size_str.c
+++ b/use-cases/utils/size_str.c
@@ -37,7 +37,7 @@ size_to_str(char *outbuf, size_t outbuflen, size_t size)
    size_t frac_val  = 0;
    int is_approx = false;
 
-   char *units = NULL;
+   const char *units = NULL;
    if (size >= SZ_TiB) {
       unit_val  = SZ_B_TO_TiB(size);
       frac_val  = SZ_B_TO_TiB_FRACT(size);
@@ -100,7 +100,7 @@ value_to_str(char *outbuf, size_t outbuflen, size_t value)
    size_t frac_val  = 0;
    int is_approx = false;
 
-   char *units = NULL;
+   const char *units = NULL;
    if (value >= VAL_Trillion) {
       unit_val  = VAL_N_TO_Trillion(value);
       frac_val  = VAL_N_TO_Trillion_FRACT(value);


### PR DESCRIPTION
This commit introduces a very basic spdlog-tutorial program.

- Add use-cases/spdlog-Cpp-program/test-main.cpp
- Makefile:
   - Add build-rules to build this source on Linux, Mac/OSX and Docker
   - New target spdlog-cpp-program; needs CC=g++ LD=g++
   - Handle env-var RUN_ON_CI, to fix SPD_INCLUDE_ROOT path that works on CI-Mac/OSX machines, as installed by `brew install`

- test.sh:
   - Add test-build-and-run-spdlog-sample

- CI/build.yml:
   - Install required pre-requisite packages, spdlog and fmt
   - Customize install env for Linux & Mac/OSX
   - Provide special-invocation env-var: RUN_ON_CI=1

------

## [Perf] Extend client-server perf tests to run with spdlog-logging

This commits injects spdlog-logging into the existing client-server performance u-benchmarking programs.

Usage:

```
make clean && CC=g++ LD=g++ L3_ENABLED=0 L3_LOGT_SPDLOG=1 make client-server-perf-test  # C++ spdlog logging
make clean && CC=g++ LD=g++ L3_ENABLED=0 L3_LOGT_SPDLOG=2 make client-server-perf-test  # C++ spdlog backtrace
```

- Makefile:
      - Extend build-rules to compile programs with above env-vars
      - Cleanup CPPFLAGS definitions to get all programs' builds working.
      - Deal with .c files that are compiled with g++ for spdlog usage.

- test.sh:
      - Add test-build-and-run-client-server-perf-test-spdlog
      - Add above test-method to run-all-client-server-perf-tests
      - CI: New tests are automatically executed as CI runs prev `run-all` test-method.

     - Fix Mac/OSX porting issues for spdlog related perf-tests.

 - svmsg_file_server.c: Add conditional code to call spdlog interfaces to initiate
      logging. Invoke logging to a file and also backtrace logging.

      Small set of changes to compile .c file using C++ compiler.
