### PR TITLE
Fix regr from previous commit. Affects perf test-runs.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -438,17 +438,17 @@ function run-all-client-server-perf-tests()
 
     echo "${Me}: $(TZ="America/Los_Angeles" date) Run all client(s)-server communication test."
     echo " "
-    test-build-and-run-client-server-perf-test "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test "${SvrClockArg}" "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-fprintf "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test-fprintf "${SvrClockArg}" "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-write "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test-write "${SvrClockArg}" "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-l3_loc_eq_1 "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test-l3_loc_eq_1 "${SvrClockArg}" "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test-l3_loc_eq_2 "${SvrClockArg}" "${num_msgs_per_client}"
 
-    test-build-and-run-client-server-perf-test-spdlog "${num_msgs_per_client}"
+    test-build-and-run-client-server-perf-test-spdlog "${SvrClockArg}" "${num_msgs_per_client}"
 
     echo " "
     set -x


### PR DESCRIPTION
Fix the calls to individual perf test-methods from `run-all-client-server-perf-tests()`. 

The interface for all these perf-test methods has been changed to receive "server clock-id" string arg as 1st param. Changes in previous commit has broken the calling sequence, and this commit fixes it.