### PR TITLE
[Perf] Support multi-threaded server execution. Update test.sh perf methods.

### DIFF
--- a/scripts/ipcrm.sh
+++ b/scripts/ipcrm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# ##############################################################################
+# Release unused shared segments.
+#
+# History:
+#	May-2024	Written; developing perf u-benchmarking scripts for L3-logging
+# ##############################################################################
+
+set -e -u -o pipefail
+
+Me=$(basename "$0")
+
+for shmid in $(ipcs -m | grep -w '0' | awk '{print $2}'); do
+
+	echo "$Me: Releasing shmid $shmid"
+	ipcrm -m ${shmid}
+done
+
+for msqid in $(ipcs -q | grep -v -i -w -E '1|Message|msqid' | awk '{print $2}'); do
+    echo "${msqid}"
+	ipcrm -q ${msqid}
+done
+
+ipcs -am

--- a/tests/pytests/perf_report_test.py
+++ b/tests/pytests/perf_report_test.py
@@ -67,18 +67,20 @@ def test_parse_perf_line_names():
 def test_parse_perf_line_values():
     """Verify parsing and output from parse_perf_line_values()"""
 
-    (run_type, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG1)
+    (run_type, nthreads_field, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG1)
 
     assert run_type == 'Baseline - No logging'
+    assert nthreads_field == 'NumThreads=1'
     assert svr_value == 91795
     assert svr_str == '~91.79 K ops/sec'
     assert cli_value == 20938
     assert cli_str == '~20.93 K ops/sec'
     assert thread_str == '5 K'
 
-    (run_type, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG2)
+    (run_type, nthreads_field, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG2)
 
     assert run_type == 'Field is unrelated to parsing'
+    assert nthreads_field == 'Num-of-Threads=20'
     assert svr_value == 98602
     assert svr_str == '~98.60 K ops/sec'
     assert cli_value == 20938

--- a/tests/pytests/perf_report_test.py
+++ b/tests/pytests/perf_report_test.py
@@ -26,11 +26,11 @@ import perf_report
 # Canonical string generated from perf u-benchmarking scripts, used
 # to test out parsing methods.
 # pylint: disable=line-too-long
-MSG1 = 'Baseline - No logging, NumClients=5, NumOps=5000000 (5 Million), Server throughput=91795 (~91.79 K) ops/sec, Client throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 (~54.46 Billion) ns'
+MSG1 = 'Baseline - No logging, NumClients=5, NumOps=5000000 (5 Million), NumThreads=1, Server throughput=91795 (~91.79 K) ops/sec, Client throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 (~54.46 Billion) ns, NumOps/thread=5000 (5 K)'
 
 # String to test parsing out for a line with same format but different field-names
 # pylint: disable=line-too-long
-MSG2 = 'Field is unrelated to parsing, Number-of-Xacts=5, Number-of-Conns=998877 (some-text ), Metric-1 name=98602 (~98.60 K) ops/sec, Metric-2 name throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 ns'
+MSG2 = 'Field is unrelated to parsing, Number-of-Xacts=5, Number-of-Conns=998877 (some-text ), Num-of-Threads=20, Metric-1 name=98602 (~98.60 K) ops/sec, Metric-2 name throughput=20938 (~20.93 K) ops/sec, elapsed_ns=54469084570 ns, nXacts/user=2500 ()'
 
 # Strings to test out parsing done by split_field_value_str()
 FIELD1 = 'Server throughput=53856 (~53.85 K) ops/sec'
@@ -45,39 +45,45 @@ FIELD2 = 'Server throughput=989 () ops/sec'
 def test_parse_perf_line_names():
     """Verify parsing and output from parse_perf_line_names()"""
 
-    (nclients_field, nops_field, svr_metric, cli_metric) = perf_report.parse_perf_line_names(MSG1)
+    (nclients_field, nops_field, nthreads_field, svr_metric, cli_metric, thread_metric) = perf_report.parse_perf_line_names(MSG1)
 
     assert nclients_field == 'NumClients=5'
     assert nops_field == 'NumOps=5000000 (5 Million)'
+    assert nthreads_field == 'NumThreads=1'
     assert svr_metric == 'Server throughput'
     assert cli_metric == 'Client throughput'
+    assert thread_metric == 'NumOps/thread'
 
-    (nclients_field, nops_field, svr_metric, cli_metric) = perf_report.parse_perf_line_names(MSG2)
+    (nclients_field, nops_field, nthreads_field, svr_metric, cli_metric, thread_metric) = perf_report.parse_perf_line_names(MSG2)
 
     assert nclients_field == 'Number-of-Xacts=5'
     assert nops_field == 'Number-of-Conns=998877 (some-text )'
+    assert nthreads_field == 'Num-of-Threads=20'
     assert svr_metric == 'Metric-1 name'
     assert cli_metric == 'Metric-2 name throughput'
+    assert thread_metric == 'nXacts/user'
 
 # #############################################################################
 def test_parse_perf_line_values():
     """Verify parsing and output from parse_perf_line_values()"""
 
-    (run_type, svr_value, svr_str, cli_value, cli_str) = perf_report.parse_perf_line_values(MSG1)
+    (run_type, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG1)
 
     assert run_type == 'Baseline - No logging'
     assert svr_value == 91795
     assert svr_str == '~91.79 K ops/sec'
     assert cli_value == 20938
     assert cli_str == '~20.93 K ops/sec'
+    assert thread_str == '5 K'
 
-    (run_type, svr_value, svr_str, cli_value, cli_str) = perf_report.parse_perf_line_values(MSG2)
+    (run_type, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG2)
 
     assert run_type == 'Field is unrelated to parsing'
     assert svr_value == 98602
     assert svr_str == '~98.60 K ops/sec'
     assert cli_value == 20938
     assert cli_str == '~20.93 K ops/sec'
+    assert thread_str == '2500'
 
 # #############################################################################
 def test_split_field_value_str():


### PR DESCRIPTION
This commit supports use of `--num-server-threads n` arg (to the `svmsg_file_server program`) with n > 1 threads. This will invoke n-server-side threads, to receive and process the messages received from the client program.

The objective is to measure any perf-impact due to concurrent logging of messages performed by multiple server threads.

- svmsg_file_server.c:
  - Prev commit already support notion of num_threads. With this change, we are now able to execute tests using more than 1 server-thread.

  - Use atomic int support to manage updates to # client-connections globals. Adjust code to work with both C & C++ compilation.

    Fortunately, due to the simplistic client-specific way messages are received & processed, we needed no new synchronization methods between server threads. Atomic incr / decrement of book-keeping variables was sufficient.

- Each server-thread reports the # of messages it processed. Update scripts/perf_report.py to report avg # of messages processed by each thread, to check that all messages are being uniformly distributed across all threads.

- Add scripts/ipcrm.sh -- script to clean-up left-over msg queues. In some runs on AWS instances, we were seeing server seg-faults in perf-runs with spdlog logging. This causes the entire test execution to hang. test.sh is updated locally to invoke this script to clean-up left-over message queues. (The actual source of the seg-fault is still tbd.)

------

NOTE TO THE REVIEWER:

@gregthelaw -- You may want to test the new feature of server-threads out on your Linux workstation as follows:

- Single-threaded execution:

```
./test.sh run-all-client-server-perf-tests --clock-default $((1000 * 1000)) > /tmp/perf.1thread.out 2>&1
```

- Multi-threaded execution:

```
./test.sh run-all-client-server-perf-tests --clock-default $((1000 * 1000)) 2 > /tmp/perf.2threads.out 2>&1
```

If you can run these and archive the summary report in a comment, it will be useful record to archive.