### PR TITLE
[Perf] Refactor perf-test methods to run with multiple server-threads.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,25 +217,27 @@ jobs:
     #  This test will build-and-run client-server perf-test, with L3-Logging OFF
     #  (baseline) and L3-Logging ON.
     #! -------------------------------------------------------------------------
-    - name: test-build-and-run-client-server-perf-test
+    - name: test-build-and-run-client-server-perf-tests
       run: |
-        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-baseline
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-l3-log
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-fast-log-no-LOC
 
     #! -------------------------------------------------------------------------
     #  This test will build-and-run client-server perf-test, with L3-Logging
     #  ON + L3-LOC encoding scheme ON.
     #! -------------------------------------------------------------------------
-    - name: test-build-and-run-client-server-perf-test-l3_loc_eq_1
+    - name: test-build-and-run-csperf-l3_loc_eq_1
       run: |
-        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_1
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-l3_loc_eq_1
 
     #! -------------------------------------------------------------------------
     #  This test will build-and-run client-server perf-test, with L3-Logging
     #  ON + L3-LOC-ELF encoding scheme ON.
     #! -------------------------------------------------------------------------
-    - name: test-build-and-run-client-server-perf-test-l3_loc_eq_2
+    - name: test-build-and-run-csperf-l3_loc_eq_2
       run: |
-        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-client-server-perf-test-l3_loc_eq_2
+        BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-l3_loc_eq_2
 
     #! -------------------------------------------------------------------------
     - name: test-build-and-run-spdlog-sample
@@ -244,7 +246,7 @@ jobs:
     # -------------------------------------------------------------------------
     # Exercise the do-it-all perf-tests method, which is really intended for
     # use by developers, to benchmark with large # of messages. A default
-    # invocation will run with small # clients & messages.
+    # invocation will run with small # clients & messages, and 1 server-thread.
     - name: test-run-all-client-server-perf-tests
       run: ./test.sh run-all-client-server-perf-tests
 


### PR DESCRIPTION
This commit lays down the groundwork so that, in future, we can execute the client-server perf tests with different number of server-threads.

This commit refactors, renames and modularizes client-server perf-test methods in test.sh . With this commit, we continue to run tests with a single thread, preparing the ground to leverage the `--num-server-threads <n>` argument added to the server-program.

- Wholesale shortening and renaming of perf-test methods Made test-methods granular, so that each can be independently exercised and verified by dev-tests.

- Break-out test-build-and-run-client-server-perf-test() into: 
   - test-build-and-run-csperf-baseline() 
   - test-build-and-run-csperf-l3-log() 
   - test-build-and-run-csperf-fast-log-no-LOC()

- Break-out spdlog test-methods into: 
  - test-build-and-run-csperf-spdlog() 
  - test-build-and-run-csperf-spdlog-backtrace()

- Break-out build-and-run-client-server-perf-test() into 2 independent:

    - build-client-server-programs()            ... [1]

    - run-client-server-tests_vary_threads()    ... [2]
        |
        +-> run-client-server-test()            ... [3]

The idea is that in future, we will do one build [1] for a specific build-mode, and then in [2] will drive-off of an env-variable, to execute [3] for different #s of server-threads. This perf-benchmarking experiment will give us an indication of overheads due to concurrent logging, when logging-threads are increased.