### PR TITLE
Log fast single threaded improves

### DIFF
--- a/l3.S
+++ b/l3.S
@@ -1,15 +1,20 @@
 .globl l3__log_fast // l3__log_fast(msg)
 .extern l3_log
+.extern __libc_single_threaded
 
 l3__log_fast:
     mov %fs:l3_my_tid@tpoff,%eax // Fetch the TLS-stashed TID into %eax
     mov l3_log(%rip), %r8   // fetch ptr to the global l3_log into register r8
-    mov  $1, %r9
-    lock xadd %r9, (%r8)    // atomically increment-and-fetch the index field in l3_log.
-    and $0x3fff, %r9        // idx %= L3_NUM_SLOTS
+    mov $1, %r9             // prepare to increment the index
+    cmpb $0, __libc_single_threaded(%rip) // Are we single-threaded?
+    jne .single_threaded    // __libc_single_threaded != 0 so skip the lock prefix
+    lock
+.single_threaded:
+    xadd %r9,(%r8)
     add $32, %r8            // point r8 at the beginning of the l3_log.slots array.
+    and $0x3fff, %r9        // idx %= L3_NUM_SLOTS
     shl $5, %r9             // scale the index by sizeof(L3_ENTRY)
-    add %r9, %r8            // point r9 at our entry in the slots array.
+    add %r9, %r8            // point r8 at our entry in the slots array.
     mov %eax, (%r8)         // The tid is in %eax from the call to to gettid above.
 #ifdef L3_LOC_ENABLED
     add $4, %r8             // Point r8 at the loc field of the slot.

--- a/l3.S
+++ b/l3.S
@@ -2,15 +2,7 @@
 .extern l3_log
 
 l3__log_fast:
-    mov %fs:0xfffffffffffffffc,%eax // Fetch the TLS-stashed TID into %eax
-    test %rax,%rax          // Did we already stash something?
-    jnz .gotid              //      Yes: avoid the syscall because doing so is slow.
-    mov $186, %rax          //      No: 1. do the syscall. First mov __NR_gettid into %rax (i.e. the syscall number)
-    push %rcx               //          2. preserve $rcx because the syscall can trash it.
-    syscall                 //          3. do the actual syscall
-    pop %rcx                //          4. restore $rcx which the syscall will have trashed.
-    mov %eax, %fs:0xfffffffffffffffc // 5. and stuff the tid in TLS so that we don't need to do the syscall next time.
-.gotid:
+    mov %fs:l3_my_tid@tpoff,%eax // Fetch the TLS-stashed TID into %eax
     mov l3_log(%rip), %r8   // fetch ptr to the global l3_log into register r8
     mov  $1, %r9
     lock xadd %r9, (%r8)    // atomically increment-and-fetch the index field in l3_log.


### PR DESCRIPTION
An optimisation for single-threaded; gets the overhead of a `l3_log_fast()` down to 2ns on my laptop.

Also fixes the bodge I made for accessing the tid in TLS in l3.S.