### PR TITLE
Change open() flags from O_APPEND -> O_TRUNC for write() logging.

### DIFF
--- a/src/l3.c
+++ b/src/l3.c
@@ -357,7 +357,7 @@ l3_init_write(const char *path)
         return -1;
     }
 
-    l3_log_fd = open(path, (O_RDWR | O_CREAT | O_APPEND), 0666);
+    l3_log_fd = open(path, (O_RDWR | O_CREAT | O_TRUNC), 0666);
     if (l3_log_fd == -1) {
         fprintf(stderr, "%s: Error opening log-file at '%p'. Error=%d\n",
                 __func__, path, errno);


### PR DESCRIPTION
In large-volume performance benchmarking we end up generating huge log files, `/tmp/l3.c-server-test.dat`, when client-server programs are built with `L3_LOGT_WRITE=1`. For write()-logging, we append log-entries to the same file, which eventually busts-up against the disk space.

This fix corrects this by opening the file
       with: (O_RDWR | O_CREAT | O_APPEND)
rather than: (O_RDWR | O_CREAT | O_TRUNC)

flags. For performance benchmarking, there is no need to retain older log-entries.