### PR TITLE
[Perf] Enhance test.sh and perf_report.py to support multiple iterations.

### DIFF
--- a/tests/pytests/perf_report_test.py
+++ b/tests/pytests/perf_report_test.py
@@ -36,6 +36,11 @@ MSG2 = 'Field is unrelated to parsing, Number-of-Xacts=5, Number-of-Conns=998877
 FIELD1 = 'Server throughput=53856 (~53.85 K) ops/sec'
 FIELD2 = 'Server throughput=989 () ops/sec'
 
+# pylint: disable=line-too-long
+SAMPLE_SUMM_LINE = 'Summary: For 32 clients, Baseline - No logging, num_threads=1, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+# pylint: enable=line-too-long
+
 # #############################################################################
 # To see output from test-cases run:
 # $ pytest --capture=tee-sys perf_report_test.py -k test_compute_pct_drop
@@ -45,6 +50,7 @@ FIELD2 = 'Server throughput=989 () ops/sec'
 def test_parse_perf_line_names():
     """Verify parsing and output from parse_perf_line_names()"""
 
+    # pylint: disable-next=line-too-long
     (nclients_field, nops_field, nthreads_field, svr_metric, cli_metric, thread_metric) = perf_report.parse_perf_line_names(MSG1)
 
     assert nclients_field == 'NumClients=5'
@@ -54,6 +60,7 @@ def test_parse_perf_line_names():
     assert cli_metric == 'Client throughput'
     assert thread_metric == 'NumOps/thread'
 
+    # pylint: disable-next=line-too-long
     (nclients_field, nops_field, nthreads_field, svr_metric, cli_metric, thread_metric) = perf_report.parse_perf_line_names(MSG2)
 
     assert nclients_field == 'Number-of-Xacts=5'
@@ -67,6 +74,7 @@ def test_parse_perf_line_names():
 def test_parse_perf_line_values():
     """Verify parsing and output from parse_perf_line_values()"""
 
+    # pylint: disable-next=line-too-long
     (run_type, nthreads_field, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG1)
 
     assert run_type == 'Baseline - No logging'
@@ -77,6 +85,7 @@ def test_parse_perf_line_values():
     assert cli_str == '~20.93 K ops/sec'
     assert thread_str == '5 K'
 
+    # pylint: disable-next=line-too-long
     (run_type, nthreads_field, svr_value, svr_str, cli_value, cli_str, thread_str) = perf_report.parse_perf_line_values(MSG2)
 
     assert run_type == 'Field is unrelated to parsing'
@@ -121,3 +130,172 @@ def test_compute_pct_drop():
     newval = 101.81 * one_k
     pct_float = perf_report.compute_pct_drop(baseval, newval)
     assert pct_float == 10.92
+
+# #############################################################################
+def test_extract_nth_field():
+    """
+    Verify extraction logic of extract_nth_field(), using #defines.
+    """
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_NUM_CLIENTS_IDX)
+    assert field == 'Summary: For 32 clients'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_RUN_TYPE_IDX)
+    assert field == 'Baseline - No logging'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_NUM_THREADS_IDX)
+    assert field == 'num_threads=1'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_NUM_OPS_IDX)
+    assert field == 'num_ops=32000000 (32 Million) ops'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_ELAPSED_TIME_IDX)
+    assert field == 'Elapsed time=105613818950 (~105.61 Billion) ns'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_AVG_ELAPSED_TIME_IDX)
+    assert field == 'Avg. Elapsed real time=3300 ns/msg'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_SERVER_THROUGHPUT_IDX)
+    assert field == 'Server throughput=302990 (~302.99 K) ops/sec'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_CLIENT_THROUGHPUT_IDX)
+    assert field == 'Client throughput=10035 (~10.03 K) ops/sec'
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE,
+                                          perf_report.FLD_AVG_OPS_PER_THREAD_IDX)
+    assert field == 'Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+    # Negative tests: Extraction should return None for out-of-band field indices
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE, -1)
+    assert field is None
+
+    field = perf_report.extract_nth_field(SAMPLE_SUMM_LINE, 100)
+    assert field is None
+
+
+# #############################################################################
+def test_extract_nclients_ops_fields():
+    """
+    Verify the extraction logic of extract_nclients_ops_fields()
+    """
+    (nclients_msg, nops_msg) = perf_report.extract_nclients_ops_fields(SAMPLE_SUMM_LINE)
+    assert nclients_msg == 'For 32 clients'
+    assert nops_msg == '32000000 (32 Million) msgs'
+
+# #############################################################################
+def test_gen_nthreads_list():
+    """
+    Verify the extraction logic of gen_nthreads_list(), which returns a list
+    of server-thread parameters
+    """
+    # Create an input list of lines, with some duplicate rows for num_threads= field
+    # and some unique rows.
+    # pylint: disable=line-too-long
+    flines = [ 'Summary: For 32 clients, Baseline - No logging, num_threads=1, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+                , 'Summary: For 32 clients, Baseline - No logging, num_threads=1, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+                , 'Summary: For 32 clients, Baseline - No logging, num_threads=2, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+                , 'Summary: For 32 clients, Baseline - No logging, num_threads=2, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+                , 'Summary: For 32 clients, Baseline - No logging, num_threads=8, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+                ]
+    # pylint: enable=line-too-long
+
+    # Verify that the parsing routine returns this expected result.
+    exp_list_of_nthreads = [ 'num_threads=1',  'num_threads=2', 'num_threads=8' ]
+
+    list_of_nthreads = perf_report.gen_nthreads_list(flines)
+    assert list_of_nthreads == exp_list_of_nthreads
+
+# #############################################################################
+def test_gen_runtypes_list():
+    """
+    Verify the extraction logic of gen_runtypes_list(), which returns a list
+    of logging run-types
+    """
+    # Create an input list of the same lines, with some duplicate rows for run-type
+    # fields and some unique rows.
+    # pylint: disable=line-too-long
+    flines = [
+                'Summary: For 32 clients, spdlog-backtrace-logging, num_threads=8, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+
+                , 'Summary: For 32 clients, L3-logging (no LOC), num_threads=2, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+                , 'Summary: For 32 clients, L3-logging (no LOC), num_threads=2, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+              ,  'Summary: For 32 clients, Baseline - No logging, num_threads=1, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+                , 'Summary: For 32 clients, Baseline - No logging, num_threads=1, num_ops=32000000 (32 Million) ops, Elapsed time=105613818950 (~105.61 Billion) ns, Avg. Elapsed real time=3300 ns/msg, Server throughput=302990 (~302.99 K) ops/sec, Client throughput=10035 (~10.03 K) ops/sec, Avg. ops per thread=32000000 (32 Million) ops/thread'
+
+                ]
+    # pylint: enable=line-too-long
+
+    # Verify that the parsing routine returns this expected result, reordering
+    # the run-types so that the Baseline row is the 1st one.
+    exp_list_of_run_types = [  'Baseline - No logging'
+                             , 'L3-logging (no LOC)'
+                             , 'spdlog-backtrace-logging'
+                            ]
+
+    list_of_run_types = perf_report.gen_runtypes_list(flines)
+    assert list_of_run_types == exp_list_of_run_types
+
+    # 0th row is always expected to be the baseline (no-logging) run-type
+    assert list_of_run_types[0].startswith('Baseline')
+
+# #############################################################################
+def test_strip_parens_etc():
+    """
+    Verify stripped string returned by strip_parens_etc()
+    """
+
+    item = '(~10.03 K) ops/sec'
+    assert perf_report.strip_parens_etc(item) == '10.03 K ops/sec'
+
+    item = '(10.03 K) ops/sec'
+    assert perf_report.strip_parens_etc(item) == '10.03 K ops/sec'
+
+    item = '10.03 K ops/sec'
+    assert perf_report.strip_parens_etc(item) == '10.03 K ops/sec'
+
+# #############################################################################
+def test_extract_metrics():
+    """
+    Verify tuple returned by extract_metrics() on a summary output line.
+    """
+    # pylint: disable=line-too-long
+    (svr_value, cli_value, svr_units_val, svr_units_str, cli_units_val, cli_units_str, thread_str) = perf_report.extract_metrics(SAMPLE_SUMM_LINE)
+
+    print(f"'{svr_value}' '{cli_value}' '{svr_units_val}' '{svr_units_str} '{cli_units_val}' '{cli_units_str}' '{thread_str}'")
+
+    # pylint: enable=line-too-long
+
+    assert svr_value == 302990
+    assert cli_value == 10035
+    assert svr_units_val == 302.99
+    assert svr_units_str == 'K ops/sec'
+    assert cli_units_val == 10.03
+    assert cli_units_str == 'K ops/sec'
+    assert thread_str == '32 Million ops'
+
+# #############################################################################
+def test_line_matches():
+    """
+    Verify boolean returned by line_matches() on a summary output line.
+    """
+    assert perf_report.line_matches(SAMPLE_SUMM_LINE,
+                                    'num_threads=1', 'Baseline - No logging') is True
+
+    assert perf_report.line_matches(SAMPLE_SUMM_LINE,
+                                    'num_threads=2', 'Baseline - No logging') is False
+
+    assert perf_report.line_matches(SAMPLE_SUMM_LINE,
+                                    'num_threads=1', 'L3-logging (no LOC)') is False


### PR DESCRIPTION

In previous performance test-runs, we were able to only run one iteration of the client-server program for each run-type, test-parameter. We were seeing some fluctuations and unexpected results in the comparison report.

This commit enhances the testing framework to:
 a) Run 1 or more iterations of the client/server program
 b) Extend the Python perf-comparison report generator to work
    with another source of input metrics-line(s).
 c) Comparison report generated using median value of the
    relevant metric across the n-iterations.

Note: (b) was needed as runs on AWS were aborted midway and had to be partially re-run. We add Python parsing logic to extract out and massage metrics from "Summary: " output lines, that the server program emits to `stdout`.

- To run multiple iterations, use env-var L3_PERF_TEST_NUM_ITERS=<n>

Workflow to run the enhanced perf_report.py:

  - Run test.sh with diff server-threads and #iterations.

Example:
 L3_PERF_TEST_NUM_ITERS=5 L3_PERF_SERVER_NUM_THREADS="1 2 4 8" ./test.sh --clock-default $((1000 * 1000))

  - Redirect output to a /tmp/file: > /tmp/perf.out 2>&1

  - grep 'Summary:' /tmp/perf.out > /tmp/perf.summary.out

  - Feed the summary file to the Python tool using:

    ./scripts/perf_report.py --summary-file /tmp/perf.summary.out

- tests/pytests/perf_report_test.py:

  - Add unit-test cases for new parsing methods added