### PR TITLE
Initial C++20 source_location{} use-case program, make source-location-cpp20-program.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,10 @@ jobs:
     - name: test-build-and-run-spdlog-sample
       run: RUN_ON_CI=1 ./test.sh test-build-and-run-spdlog-sample
 
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-source-location-cpp20-sample
+      run: ./test.sh test-build-and-run-source-location-cpp20-sample
+
     # -------------------------------------------------------------------------
     # Exercise the do-it-all perf-tests method, which is really intended for
     # use by developers, to benchmark with large # of messages. A default

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ help::
 	@echo 'To build spdlog:'
 	@echo ' make clean && CC=g++ LD=g++ make spdlog-cpp-program'
 	@echo ' '
+	@echo 'To build C++20 source-location sample program:'
+	@echo ' make clean && CXX=g++ LD=g++ L3_ENABLED=0 make source-location-cpp20-program'
+	@echo ' '
 	@echo 'Environment variables: '
 	@echo '  BUILD_MODE={release,debug}'
 	@echo '  BUILD_VERBOSE={0,1}'
@@ -464,6 +467,25 @@ SPD_INCLUDE := $(SPD_INCLUDE_ROOT)/include
 spdlog-cpp-program: INCLUDE += -I $(SPD_INCLUDE)
 spdlog-cpp-program: LIBS += $(SPD_LIBS_PATH) -l spdlog -l fmt
 spdlog-cpp-program: $(SPDLOG_EXAMPLE_PROGRAM_BIN)
+
+# ##############################################################################
+# Rules to build source-location sample program that needs C++20 support.
+# ##############################################################################
+SRCLOC_EXAMPLE_PROG_DIR     := $(USE_CASES)/source-location-Cpp-program
+
+SRCLOC_EXAMPLE_PROG_SRCS    := $(wildcard $(SRCLOC_EXAMPLE_PROG_DIR)/*.cpp)
+
+# Map the list of sources to resulting list-of-objects
+SRCLOC_EXAMPLE_PROG_OBJS    := $(SRCLOC_EXAMPLE_PROG_SRCS:%.cpp=$(OBJDIR)/%.o)
+
+# Define a dependency of this example program's binary to its list of objects
+SRCLOC_EXAMPLE_PROGRAM_BIN  := $(BINDIR)/$(SRCLOC_EXAMPLE_PROG_DIR)
+$(SRCLOC_EXAMPLE_PROGRAM_BIN): $(SRCLOC_EXAMPLE_PROG_OBJS)
+
+# Required .h is in the same source dir
+source-location-cpp20-program: CPPFLAGS = --std=c++20
+source-location-cpp20-program: INCLUDE += -I $(SRCLOC_EXAMPLE_PROG_DIR)
+source-location-cpp20-program: $(SRCLOC_EXAMPLE_PROGRAM_BIN)
 
 # ##############################################################################
 # Build symbols for single C & C++ unit-test binary that we run

--- a/test.sh
+++ b/test.sh
@@ -131,6 +131,9 @@ TestList=(
            # spdlog-related test methods
            "test-build-and-run-spdlog-sample"
 
+           # C++20 source_location{}-related test methods
+           "test-build-and-run-source-location-cpp20-sample"
+
            # Driver methods, listed here for quick debugging.
            # Not intended for use by test-execution.
            "run-client-server-tests_vary_threads"
@@ -1122,6 +1125,24 @@ function test-build-and-run-spdlog-sample()
     set +x
     echo " "
     echo "${Me}: Run spdlog sample program ..."
+    echo " "
+
+    set -x
+    ${test_prog}
+}
+
+# #############################################################################
+# Build-and-run the C++20 source_location{} sample program.
+# #############################################################################
+function test-build-and-run-source-location-cpp20-sample()
+{
+    make clean && CXX=g++ LD=g++ L3_ENABLED=0 make source-location-cpp20-program
+
+    local test_prog="./build/${Build_mode}/bin/use-cases/source-location-Cpp-program"
+
+    set +x
+    echo " "
+    echo "${Me}: Run C++20 source_location sample program ..."
     echo " "
 
     set -x

--- a/use-cases/source-location-Cpp-program/source-location-log.cpp
+++ b/use-cases/source-location-Cpp-program/source-location-log.cpp
@@ -1,0 +1,26 @@
+/**
+ * source-location-log.cpp
+ */
+/**
+ * log() - Generic logging method to print source-code-location and a msg.
+ */
+#include <iostream>
+#include <source_location>
+
+std::source_location
+log(const std::string_view msg,
+    const std::source_location loc = std::source_location::current())
+{
+    std::cout << "\n"
+              << loc.file_name()     << ':'
+              << loc.line()          << ':'
+              << loc.column()        << "::"
+              << loc.function_name()
+              << ": '" << msg << "'"
+              << '\n';
+
+    // Return instance of source_location where this logging happened at.
+    std::source_location curr_location = std::source_location::current();
+
+    return curr_location;
+}

--- a/use-cases/source-location-Cpp-program/source-location-main-C++20.cpp
+++ b/use-cases/source-location-Cpp-program/source-location-main-C++20.cpp
@@ -1,0 +1,44 @@
+/*
+ * C++ 20 has intrinsic support for this file/line# combo through the
+ * source_location{} object.
+ *
+ * This sample program is copied from:
+ * https://en.cppreference.com/w/cpp/utility/source_location
+ */
+#include <iostream>
+#include <string_view>
+#include <source_location>
+
+#include "source-location.h"
+
+/**
+ * some_func() - Some templatized function to invoke generic log()'ging method.
+ */
+template<typename T>
+void some_func(T x)
+{
+    std::source_location callee = LOG(x);
+
+    pr_source_location(callee, " [Callee: template<T> func()]");
+}
+
+int main(const int argc, char * argv[])
+{
+    std::cout << __func__ << "(): Size of std::source_location: "
+              << sizeof(std::source_location) << " bytes"
+              << '\n';
+
+    std::source_location callee = LOG("Hello world: Lock Acquire!");
+
+    std::cout << "\nDIAG: "
+              << callee.file_name()     << ':'
+              << callee.line()          << ':'
+              << callee.column()        << "::"
+              << callee.function_name()
+              << " [whoami: main()]"
+              << '\n';
+
+    some_func("Hello C++20: Lock Release!");
+
+    minion();
+}

--- a/use-cases/source-location-Cpp-program/source-location-minion.cpp
+++ b/use-cases/source-location-Cpp-program/source-location-minion.cpp
@@ -1,0 +1,20 @@
+/** source-location-minion.cpp
+ */
+#include <string>
+#include "source-location.h"
+
+/**
+ * minion() : Shows an example usage of LOG() interface where we can silently
+ * ignore the returned std::source_location.
+ * There is no hard requirement for caller to save that returned handle.
+ */
+void
+minion(void)
+{
+    // Example: You do -not- need to do this code construction:
+    // std::source_location callee = LOG("Hello from minion");
+    // pr_source_location(callee, " [Callee: minion()]");
+
+    // Simply invoke LOG() to get this source location's info
+    LOG("Hello from minion - skip returned source_location handle.");
+}

--- a/use-cases/source-location-Cpp-program/source-location-utils.cpp
+++ b/use-cases/source-location-Cpp-program/source-location-utils.cpp
@@ -1,0 +1,21 @@
+/**
+ * source-location-utils.cpp
+ */
+#include <iostream>
+#include <source_location>
+
+/**
+ * pr_source_location() - Print the contents of a source-code-location object.
+ */
+void
+pr_source_location(const std::source_location loc,
+                   const std::string msg = "")
+{
+    std::cout << "\nPR-DIAG: "
+              << loc.file_name()     << ':'
+              << loc.line()          << ':'
+              << loc.column()        << "::"
+              << loc.function_name()
+              << ": '" << msg << "'"
+              << '\n';
+}

--- a/use-cases/source-location-Cpp-program/source-location.h
+++ b/use-cases/source-location-Cpp-program/source-location.h
@@ -1,0 +1,21 @@
+/*
+ * C++ 20 has intrinsic support for this file/line# combo through the
+ * source_location{} object.
+ */
+#pragma once
+
+#include <string_view>
+#include <source_location>
+
+// Caller-macro to synthesize current source_location as 'location' arg.
+#define LOG(msg)    log((msg), std::source_location::current())
+
+// Function protoypes
+
+std::source_location
+log(const std::string_view message,         // Message to log
+    const std::source_location location);   // ... where msg is logged
+
+void minion(void);
+
+void pr_source_location(const std::source_location loc, const std::string msg);


### PR DESCRIPTION
This commit adds the initial version of a sample program to exercise C++20's feature of `std::source_location{}` object.

Enhanced source cp'ed from:
 https://en.cppreference.com/w/cpp/utility/source_location

- Add source-location.h and  minion.cpp
- Minor refactoring of messasges.
- log() returns source_location of callee. Print that in caller.
- Refactor: Add pr_source_location().

This commit brings-in source-location-minion.cpp where another caller to LOG() macro is added. LOG() is defined in source-location.h as a caller-macro, supplying `location` arg.

- Working version of Makefile: make source-location-cpp20-program
  - make target works on Linux-VM, and also on Mac/OSX in CI.
- Add test-build-and-run-source-location-cpp20-sample() test-method.
- Distribute helper fns to log.cpp and utils.cpp, for a slightly realistic version of a real code-base (rather than a tutorial).

-------

NOTE TO the reviewer: @gregthelaw - this is a simple C++ tutorial to demo the use of source_location{}.

I am preparing the slide deck for the preso, and forgot that this change was ready but languishing elsewhere. 

Rebased this off of /main and it should be ready to go. If you get to review this soon, that will be good. Otherwise, I might just integrate this as it does not affect core L3 files.