### PR TITLE
More fixes to use of TLS from assembly code.

### DIFF
--- a/l3.S
+++ b/l3.S
@@ -4,6 +4,15 @@
 
 l3__log_fast:
     mov %fs:l3_my_tid@tpoff,%eax // Fetch the TLS-stashed TID into %eax
+    cmp $0, %eax            // Is the TID already stashed?
+    jnz .tid_stashed        // yes: skip the call to gettid
+    mov $186, %eax          // syscall number for gettid
+    push %rcx
+    syscall
+    pop %rcx
+    mov %eax, %fs:l3_my_tid@tpoff // store the TID in TLS.
+.tid_stashed:
+    mov %rax, %r10          // get the TID into %r10
     mov l3_log(%rip), %r8   // fetch ptr to the global l3_log into register r8
     mov $1, %r9             // prepare to increment the index
     cmpb $0, __libc_single_threaded(%rip) // Are we single-threaded?

--- a/src/l3.c
+++ b/src/l3.c
@@ -184,7 +184,7 @@ getBaseAddress() {
 }
 #endif  // __APPLE__
 
-L3_THREAD_LOCAL pid_t l3_my_tid;
+L3_THREAD_LOCAL pid_t l3_my_tid = 0;
 
 /**
  * ****************************************************************************
@@ -278,8 +278,6 @@ l3_init(const char *path)
             return -1;
         }
     }
-
-    l3_my_tid = L3_GET_TID();
 
     l3_log = (L3_LOG *) mmap(NULL, sizeof(*l3_log), PROT_READ|PROT_WRITE,
                              MAP_SHARED, fd, 0);
@@ -398,6 +396,7 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
     int idx = __libc_single_threaded ? l3_log->idx++
                                      : __sync_fetch_and_add(&l3_log->idx, 1);
 #endif  // __APPLE__
+    if (!l3_my_tid) l3_my_tid = L3_GET_TID();
     idx %= L3_MAX_SLOTS;
     l3_log->slots[idx].tid = l3_my_tid;
 

--- a/src/l3.c
+++ b/src/l3.c
@@ -396,7 +396,9 @@ l3_log_mmap(const char *msg, const uint64_t arg1, const uint64_t arg2,
     int idx = __libc_single_threaded ? l3_log->idx++
                                      : __sync_fetch_and_add(&l3_log->idx, 1);
 #endif  // __APPLE__
-    if (!l3_my_tid) l3_my_tid = L3_GET_TID();
+    if (!l3_my_tid) {
+        l3_my_tid = L3_GET_TID();
+    }
     idx %= L3_MAX_SLOTS;
     l3_log->slots[idx].tid = l3_my_tid;
 


### PR DESCRIPTION
My previous attempt to fix usage of TLS wasn't right because child threads would not have their TLS thread initialised. This PR fixes that by zero-initialising the TLS thread, and checking it from every call.