### PR TITLE
Add some multi-threaded micro-benchmarks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,12 +240,18 @@ jobs:
         BUILD_MODE=${{ matrix.build_type }} ./test.sh test-build-and-run-csperf-l3_loc_eq_2
 
     #! -------------------------------------------------------------------------
+    # RUN_ON_CI=1 to trigger right selection of spdlog library path on CI-jobs
+    # that run on Mac/OSX machines.
     - name: test-build-and-run-spdlog-sample
       run: RUN_ON_CI=1 ./test.sh test-build-and-run-spdlog-sample
 
     #! -------------------------------------------------------------------------
     - name: test-build-and-run-source-location-cpp20-sample
       run: ./test.sh test-build-and-run-source-location-cpp20-sample
+
+    #! -------------------------------------------------------------------------
+    - name: test-build-and-run-multi-threaded-perf-ubm
+      run: RUN_ON_CI=1 ./test.sh test-build-and-run-multi-threaded-perf-ubm
 
     # -------------------------------------------------------------------------
     # Exercise the do-it-all perf-tests method, which is really intended for

--- a/test.sh
+++ b/test.sh
@@ -134,6 +134,9 @@ TestList=(
            # C++20 source_location{}-related test methods
            "test-build-and-run-source-location-cpp20-sample"
 
+           # L3 v/s spdlog [etc] micro performance benchmarking
+           "test-build-and-run-multi-threaded-perf-ubm"
+
            # Driver methods, listed here for quick debugging.
            # Not intended for use by test-execution.
            "run-client-server-tests_vary_threads"
@@ -1147,6 +1150,14 @@ function test-build-and-run-source-location-cpp20-sample()
 
     set -x
     ${test_prog}
+}
+
+# #############################################################################
+# Build-and-run the L3 v/s spdlog [etc] micro performance benchmarking
+# #############################################################################
+function test-build-and-run-multi-threaded-perf-ubm()
+{
+    make clean && CXX=g++ LD=g++ make all-mt-ubench && make run-mt-ubench
 }
 
 # #############################################################################

--- a/tests/perf/Makefile
+++ b/tests/perf/Makefile
@@ -1,0 +1,8 @@
+all: l3.exe spdlog.exe
+
+l3.exe: mt_ubench_l3.cpp
+	g++ -Ofast -o l3.exe -I../../include mt_ubench_l3.cpp ../../src/l3.c ../../l3.S -lpthread
+
+spdlog.exe: mt_ubench_spdlog.cpp
+	g++ -Ofast -o spdlog.exe mt_ubench_spdlog.cpp -lpthread
+

--- a/tests/perf/Makefile
+++ b/tests/perf/Makefile
@@ -1,8 +1,0 @@
-all: l3.exe spdlog.exe
-
-l3.exe: mt_ubench_l3.cpp
-	g++ -Ofast -o l3.exe -I../../include mt_ubench_l3.cpp ../../src/l3.c ../../l3.S -lpthread
-
-spdlog.exe: mt_ubench_spdlog.cpp
-	g++ -Ofast -o spdlog.exe mt_ubench_spdlog.cpp -lpthread
-

--- a/tests/perf/mt_ubench_l3.cpp
+++ b/tests/perf/mt_ubench_l3.cpp
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "l3.h"
+
+int gettid() {
+    return syscall(SYS_gettid);
+}
+
+pthread_barrier_t barrier;
+
+int main(int argc, char** argv) {
+    int nthreads = argc == 1 ? 10 : atoi(argv[1]);
+    pthread_t threads[nthreads];
+    int e = pthread_barrier_init(&barrier, NULL, nthreads+1);
+    assert(!e);
+    l3_init("/tmp/l3.log");
+    for (int i = 0; i < nthreads; i++) {
+        pthread_create(&threads[i], NULL, [](void*) -> void* {
+            int e = pthread_barrier_wait(&barrier);
+            assert(e == 0 || e == PTHREAD_BARRIER_SERIAL_THREAD);
+            for (int j = 0; j < 1000000; j++) {
+                l3_log_fast("Hello, world! %d %d", 0, j);
+            }
+            return nullptr;
+        }, nullptr);
+    }
+        pthread_barrier_wait(&barrier);
+
+    for (int i = 0; i < nthreads; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    return 0;
+}

--- a/tests/perf/mt_ubench_l3.cpp
+++ b/tests/perf/mt_ubench_l3.cpp
@@ -1,35 +1,59 @@
-#include <assert.h>
-#include <pthread.h>
-#include <stdlib.h>
+/**
+ * *****************************************************************************
+ * \file perf/mt_ubench_l3.cpp
+ * \author Greg Law
+ * \brief L3: Fast-logging micro perf-benchmarking
+ * \version 0.1
+ * \date 2024-06-25
+ *
+ * \copyright Copyright (c) 2024
+ *
+ * Usage: program-name [ <number-of-threads> ]
+ * *****************************************************************************
+ */
 #include <stdio.h>
-#include <sys/syscall.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <assert.h>
+#include <sys/syscall.h>
+#include <pthread.h>
 
 #include "l3.h"
 
-int gettid() {
-    return syscall(SYS_gettid);
-}
+// Micro perf benchmarking workload parameter defaults
+constexpr int L3_PERF_UBM_NTHREADS = 10;
+constexpr int L3_PERF_UBM_NMSGS = (1000 * 1000);
 
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
 pthread_barrier_t barrier;
+#endif
 
 int main(int argc, char** argv) {
-    int nthreads = argc == 1 ? 10 : atoi(argv[1]);
+    int nthreads = ((argc > 1) ? atoi(argv[1]) : L3_PERF_UBM_NTHREADS);
+    // int nmsgs = ((argc > 2) ? atoi(argv[2]) : L3_PERF_UBM_NMSGS);
+
     pthread_t threads[nthreads];
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
     int e = pthread_barrier_init(&barrier, NULL, nthreads+1);
     assert(!e);
+#endif
+
     l3_init("/tmp/l3.log");
     for (int i = 0; i < nthreads; i++) {
-        pthread_create(&threads[i], NULL, [](void*) -> void* {
+        pthread_create(&threads[i], NULL, [](void *) -> void * {
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
             int e = pthread_barrier_wait(&barrier);
             assert(e == 0 || e == PTHREAD_BARRIER_SERIAL_THREAD);
-            for (int j = 0; j < 1000000; j++) {
+#endif
+            for (int j = 0; j < L3_PERF_UBM_NMSGS; j++) {
                 l3_log_fast("Hello, world! %d %d", 0, j);
             }
             return nullptr;
         }, nullptr);
     }
-        pthread_barrier_wait(&barrier);
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
+    pthread_barrier_wait(&barrier);
+#endif
 
     for (int i = 0; i < nthreads; i++) {
         pthread_join(threads[i], NULL);

--- a/tests/perf/mt_ubench_spdlog.cpp
+++ b/tests/perf/mt_ubench_spdlog.cpp
@@ -1,31 +1,67 @@
+/**
+ * *****************************************************************************
+ * \file perf/mt_ubench_spdlog.cpp
+ * \author Greg Law
+ * \brief L3: spdlog-multi-threaded logging micro perf-benchmarking
+ * \version 0.1
+ * \date 2024-06-25
+ *
+ * \copyright Copyright (c) 2024
+ *
+ * Usage: program-name [ <number-of-threads> ]
+ * *****************************************************************************
+ */
+#include <stdlib.h>
+#include <pthread.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
-#include <stdlib.h>
 
-#include <pthread.h>
+
+// Micro perf benchmarking workload parameter defaults
+constexpr int L3_PERF_UBM_NTHREADS = 10;
+constexpr int L3_PERF_UBM_NMSGS = (1000 * 1000);
+constexpr int L3_PERF_UBM_LOG_SIZE = (16 * 1024);
+
+#if __APPLE__
+#define L3_GET_TID()    pthread_mach_thread_np(pthread_self())
+#else
+#define L3_GET_TID()    syscall(SYS_gettid)
+#endif  // __APPLE__
 
 std::shared_ptr<spdlog::logger> logger;
 
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
 pthread_barrier_t barrier;
-
+#endif
 
 int main(int argc, char** argv) {
-    int nthreads = argc == 1 ? 10 : atoi(argv[1]);
-    pthread_barrier_init(&barrier, NULL, nthreads+1);
+    int nthreads = ((argc > 1) ? atoi(argv[1]) : L3_PERF_UBM_NTHREADS);
+    // int nmsgs = ((argc > 2) ? atoi(argv[2]) : L3_PERF_UBM_NMSGS);
+
     pthread_t threads[nthreads];
+
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
+    pthread_barrier_init(&barrier, NULL, (nthreads + 1));
+#endif
+
     logger = spdlog::basic_logger_mt("file_logger", "/tmp/logger.txt", true);
-    logger->enable_backtrace(200);
+    logger->enable_backtrace(L3_PERF_UBM_LOG_SIZE);
+
     for (int i = 0; i < nthreads; i++) {
         pthread_create(&threads[i], NULL, [](void*) -> void* {
-            int tid = syscall(SYS_gettid);
+            int tid = L3_GET_TID();
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
             pthread_barrier_wait(&barrier);
-            for (int j = 0; j < 1000000; j++) {
+#endif
+            for (int j = 0; j < L3_PERF_UBM_NMSGS; j++) {
                 logger->info("{}: Hello, World! tid: {}", j, tid);
             }
             return nullptr;
         }, nullptr);
     }
+#if !defined(_POSIX_BARRIERS) || _POSIX_BARRIERS > 0
     pthread_barrier_wait(&barrier);
+#endif
 
     for (int i = 0; i < nthreads; i++) {
         pthread_join(threads[i], NULL);

--- a/tests/perf/mt_ubench_spdlog.cpp
+++ b/tests/perf/mt_ubench_spdlog.cpp
@@ -1,0 +1,34 @@
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <stdlib.h>
+
+#include <pthread.h>
+
+std::shared_ptr<spdlog::logger> logger;
+
+pthread_barrier_t barrier;
+
+
+int main(int argc, char** argv) {
+    int nthreads = argc == 1 ? 10 : atoi(argv[1]);
+    pthread_barrier_init(&barrier, NULL, nthreads+1);
+    pthread_t threads[nthreads];
+    logger = spdlog::basic_logger_mt("file_logger", "/tmp/logger.txt", true);
+    logger->enable_backtrace(200);
+    for (int i = 0; i < nthreads; i++) {
+        pthread_create(&threads[i], NULL, [](void*) -> void* {
+            int tid = syscall(SYS_gettid);
+            pthread_barrier_wait(&barrier);
+            for (int j = 0; j < 1000000; j++) {
+                logger->info("{}: Hello, World! tid: {}", j, tid);
+            }
+            return nullptr;
+        }, nullptr);
+    }
+    pthread_barrier_wait(&barrier);
+
+    for (int i = 0; i < nthreads; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    return 0;
+}


### PR DESCRIPTION
Spawn 10 threads, each does a million logs.
We have two: one for L3 and one for spdlog.

For this test, L3 is over 20x faster than spdlog.

```
$ time ./spdlog.exe 

real    0m18.050s
user    0m29.033s
sys     1m17.579s
$
$
$ time ./l3.exe 

real    0m0.814s
user    0m6.623s
sys     0m0.028s
$
```