### PR TITLE
Proof of concept: Variable args count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 *.swp
-# Skip build/ areas
+# Skip build artifacts
 build*
+*.o
 # Skip LOC-generated files
 loc*h
 loc_filenames.c
 
 # Skip pytests cached files
 *__pycache__*
+
+# Skip samples
+*-sample*

--- a/README.md
+++ b/README.md
@@ -38,24 +38,24 @@ struct {
     pid_t tid;          // User thread-ID
     int32_t loc;        // (Optional) Line-of-Code ID
     const char *msg;    // Diagnostic message literal
-    uint64_t arg1;      // Argument value-1
-    uint64_t arg2;      // Argument value-2
+    uint64_t argsN;     // Number of arguments
 };
 ```
+
+Where arguments (if present) are stored directly before their corresponding `struct`.
 
 The array is backed by a memory-mapped file, filename given by `l3_init()`.
 The logging routines simply do an atomic fetch-and-increment of a
 global index to get a slot into the array, and then update that slot
-with the calling thread ID, a pointer to a message string, and up to
-two 64-bit arguments. (We store just the pointer to the string rather than
-string itself because this is usually a lot faster and, of course, consumes
-less storage space.)
+with the calling thread ID, a pointer to a message string, and the accompanying
+arguments. (We store just the pointer to the string rather thanstring itself because
+this is usually a lot faster and, of course, consumes less storage space.)
 
 **The address must be a pointer to a string literal.**
 
 The `l3_dump.py` utility will map the pointer to find the string
 literal to which it points from the executable, to generate a human-readable
-dump of the log.
+dump of the log (with the most recent messages printed first).
 
 ------
 

--- a/l3.c
+++ b/l3.c
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdarg.h>
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <sys/syscall.h>
@@ -50,24 +51,25 @@
 /**
  * L3 Log entry Structure definitions:
  */
-typedef struct l3_entry
+typedef union l3_entry
 {
-    pid_t       tid;
-#ifdef L3_LOC_ENABLED
-    loc_t       loc;
-#else
-    uint32_t    loc;
-#endif  // L3_LOC_ENABLED
-    const char *msg;
-    uint64_t    arg1;
-    uint64_t    arg2;
-} L3_ENTRY;
+    struct l3_arguments
+    {
+        uint64_t args[3];
+    } body;
 
-/**
- * The L3-dump script expects a specific layout and its parsing routines
- * hard-code the log-entry size to be these many bytes.
- */
-#define L3_LOG_ENTRY_SZ (4 * sizeof(uint64_t))
+    struct l3_footer
+    {
+        pid_t       tid;
+    #ifdef L3_LOC_ENABLED
+        loc_t       loc;
+    #else
+        uint32_t    loc;
+    #endif  // L3_LOC_ENABLED
+        const char *msg;
+        uint64_t    argN;
+    } foot;
+} L3_ENTRY;
 
 /**
  * Cross-check LOC's data structures. We need this to be true to ensure
@@ -104,28 +106,18 @@ enum loc_type_t
  */
 typedef struct l3_log
 {
-    uint64_t        idx;
+    uint64_t        idx; // Offset into `slots` for where the next entry is to be written. Atomic.
     uint64_t        fbase_addr;
-    uint32_t        pad0;
-    uint16_t        log_size;   // # of log-entries == L3_MAX_SLOTS
+    uint32_t        slot_count; // == L3_MAX_SLOTS. For determining the size of the ring buffer when decoding.
+    uint16_t        pad2;
     uint8_t         platform;
     uint8_t         loc_type;
     uint64_t        pad1;
-    L3_ENTRY        slots[L3_MAX_SLOTS];
+    L3_ENTRY        slots[0];
 } L3_LOG;
 
 
 L3_LOG *l3_log = NULL;      // L3_LOG_MMAP: Also referenced in l3.S.
-
-/**
- * The L3-dump script expects a specific layout and its parsing routines
- * hard-code the log-header size to be these many bytes. (The overlay of
- * L3_LOG{} and L3_ENTRY{}'s size is somewhat of a convenience. They just
- * happen to be of the same size, as of now, hence, this reuse.)
- */
-L3_STATIC_ASSERT(offsetof(L3_LOG,slots) == sizeof(L3_ENTRY),
-                "Expected layout of L3_LOG{} is != 32 bytes.");
-
 
 #if __APPLE__
 
@@ -155,6 +147,7 @@ L3_THREAD_LOCAL pid_t l3_my_tid = 0;
 int
 l3_init(const char *path)
 {
+    uint64_t fsize = sizeof(L3_LOG) + L3_MAX_SLOTS * sizeof(L3_ENTRY);
     int fd = -1;
     if (path)
     {
@@ -162,8 +155,7 @@ l3_init(const char *path)
         if (fd == -1) {
             return -1;
         }
-
-        if (lseek(fd, sizeof(L3_LOG), SEEK_SET) < 0) {
+        if (lseek(fd, fsize, SEEK_SET) < 0) {
             return -1;
         }
         if (write(fd, &fd, 1) != 1) {
@@ -171,7 +163,7 @@ l3_init(const char *path)
         }
     }
 
-    l3_log = (L3_LOG *) mmap(NULL, sizeof(*l3_log), PROT_READ|PROT_WRITE,
+    l3_log = (L3_LOG *) mmap(NULL, fsize, PROT_READ|PROT_WRITE,
                              MAP_SHARED, fd, 0);
     if (l3_log == MAP_FAILED) {
         return -1;
@@ -180,6 +172,7 @@ l3_init(const char *path)
     // Technically, this is not needed as mmap() is guaranteed to return
     // zero-filled pages. We do this just to be clear where the idx begins.
     l3_log->idx = 0;
+    l3_log->slot_count = L3_MAX_SLOTS;
 
 #if __APPLE__
      l3_log->fbase_addr = getBaseAddress();
@@ -193,7 +186,7 @@ l3_init(const char *path)
         return -1;
     }
     l3_log->fbase_addr = (intptr_t) info.dli_fbase;
-     l3_log->platform = L3_LOG_PLATFORM_LINUX;
+    l3_log->platform = L3_LOG_PLATFORM_LINUX;
 #endif  // __APPLE__
 
     // Note down, in the log-header, the type of LOC-encoding in effect.
@@ -209,8 +202,6 @@ l3_init(const char *path)
     l3_log->loc_type = L3_LOG_LOC_ENCODING;
 #endif  // L3_LOC_ELF_ENABLED
 
-    l3_log->log_size = L3_MAX_SLOTS;
-
     // printf("fbase_addr=%" PRIu64 " (0x%llx)\n", l3_log->fbase_addr, l3_log->fbase_addr);
     // printf("sizeof(L3_LOG)=%ld, header=%lu bytes\n",
     //        sizeof(L3_LOG), offsetof(L3_LOG,slots));
@@ -222,46 +213,58 @@ l3_init(const char *path)
 /**
  * l3_log_fn() - 'C' implementation of L3-logging.
  *
- * As 'loc' is an argument synthesized by the caller-macro, under conditional
- * compilation, keep it as the last argument. This makes it possible to define
- * DEBUG version of the caller-macro using printf(), for argument v/s print-
- * format specifiers in 'msg'.
+ * 'loc' is an argument synthesized by the caller-macro, under conditional.
+ * This makes it possible to define DEBUG version of the caller-macro using printf(),
+ * for argument v/s print-format specifiers in 'msg'.
  */
-void __attribute__((weak))
+void
 #ifdef L3_LOC_ENABLED
-l3_log_fn(const char *msg, const uint64_t arg1, const uint64_t arg2,
-            loc_t loc)
+l3_log_fn(const char *msg, loc_t loc, int nargs, ...)
 #else
-l3_log_fn(const char *msg, const uint64_t arg1, const uint64_t arg2,
-            uint32_t loc)
+l3_log_fn(const char *msg, uint32_t loc, int nargs, ...)
 #endif
 {
+    const uint64_t args_per_block = sizeof(L3_ENTRY) / sizeof(uint64_t);
+    uint64_t entryBlocks = 1 + (nargs + args_per_block - 1) / args_per_block;
 
-#if  __APPLE__
-    int idx = __sync_fetch_and_add(&l3_log->idx, 1);
-#else
-    int idx = __libc_single_threaded ? l3_log->idx++
-                                     : __sync_fetch_and_add(&l3_log->idx, 1);
+    uint32_t ofs;
+#ifndef  __APPLE__
+    if (__libc_single_threaded)
+    {
+        ofs = l3_log->idx;
+        l3_log->idx += entryBlocks; // the next log will write here
+    } else
 #endif  // __APPLE__
+    {
+        ofs = __sync_fetch_and_add(&l3_log->idx, entryBlocks);
+    }
+
     if (!l3_my_tid) {
         l3_my_tid = L3_GET_TID();
     }
-    idx %= L3_MAX_SLOTS;
-    l3_log->slots[idx].tid = l3_my_tid;
 
-#ifdef L3_LOC_ENABLED
-    l3_log->slots[idx].loc = (loc_t) loc;
-#else   // L3_LOC_ENABLED
+    ofs %= L3_MAX_SLOTS;
+    // printf("Logging %ld blocks from idx %ld.\n", entryBlocks, ofs);
 
-#ifdef DEBUG
-    assert(l3_log->slots[idx].loc == 0);
-#endif  // DEBUG
+    // Write the blocks. The one always fits, but the rest might need to wrap.
+    // Because 3 arguments fit in the span of the Entry's footer metadata, the byte layout may look like:
+    // [ofs+0] = Args 0-2, [ofs+1] = Args 3-5, [ofs+N] = Footer
+    va_list args;
+    va_start(args, nargs);
+    for (int i = nargs; i > 0; i -= args_per_block) {
+        for (int j = 0; j < L3_MIN(i, args_per_block); j++) {
+            l3_log->slots[ofs].body.args[j] = va_arg(args, uint64_t);
+        }
+        // wrapping increment
+        if(++ofs >= L3_MAX_SLOTS) ofs -= L3_MAX_SLOTS;
+    }
+    va_end(args);
 
-#endif  // L3_LOC_ENABLED
-
-    l3_log->slots[idx].msg = msg;
-    l3_log->slots[idx].arg1 = arg1;
-    l3_log->slots[idx].arg2 = arg2;
+    // Write the footer block.
+    l3_log->slots[ofs].foot.tid = l3_my_tid;
+    l3_log->slots[ofs].foot.loc = loc;
+    l3_log->slots[ofs].foot.msg = msg;
+    l3_log->slots[ofs].foot.argN = nargs;
 }
 
 int
@@ -278,6 +281,8 @@ l3_deinit(void)
  * Ref: https://stackoverflow.com/questions/17669593/how-to-get-a-pointer-to-a-binary-section-in-mac-os-x/22366882#22366882
  *
  * https://stackoverflow.com/questions/16552710/how-do-you-get-the-start-and-end-addresses-of-a-custom-elf-section
+ *
+ * https://www.scs.stanford.edu/~dm/blog/va-opt.html
  *
  * Some reference code to try out, some day:
  *

--- a/samples/sample-c-appln/Makefile
+++ b/samples/sample-c-appln/Makefile
@@ -29,11 +29,12 @@ L3_INCDIR   := $(L3_ROOTDIR)
 L3_SRC      := $(L3_SRCDIR)/l3.c
 
 # Currently, assembly-coded extra-fast-logging is only supported on x86 64-bit Linux.
-ifeq ($(UNAME_S),Linux)
-    ifeq ($(UNAME_P), x86_64)
-        L3_ASSEMBLY := $(L3_ROOTDIR)/l3.S
-    endif
-endif
+# NOTE (Icedude907): My changes have not been converted to assembly.
+# ifeq ($(UNAME_S),Linux)
+#     ifeq ($(UNAME_P), x86_64)
+#         L3_ASSEMBLY := $(L3_ROOTDIR)/l3.S
+#     endif
+# endif
 
 # Hard-coded name of L3 log-file created in main(). This is not really needed
 # for builds to work, but is made visible here for documentation purposes.

--- a/samples/sample-c-appln/functions.c
+++ b/samples/sample-c-appln/functions.c
@@ -3,6 +3,11 @@
 
 void call_function() {
   printf("\n%s:%d::%s() Hello World!\n", __FILE__, __LINE__, __func__);
+  l3_log("Hello World with L3-logging!");
+  l3_log("Format test: addr=%p, size=%d bytes.", 0xdeadbeef, 42);
+  l3_log("Long test: %lu %lu %lu", 0xeeeeeeeeeeeeeeee, 0xdddddddddddddddd, 0x1111111111111111);
+  l3_log("Nine args: %d %d %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  l3_log("Sample is now over%c%c%c", '!', '!', '?');
 
 #ifdef L3_LOC_ENABLED
   loc_t loc = __LOC__;
@@ -10,5 +15,4 @@ void call_function() {
          loc, LOC_FILE(loc), LOC_LINE(loc));
 #endif  // L3_LOC_ENABLED
 
-  l3_log("Hello World with L3-logging, addr=%p, size=%d bytes", 0xdeadbeef, 42);
 }


### PR DESCRIPTION
Hi there!
I commented on Greg's video the other day about the possibility of extending this to support a variable number of format arguments - got me thinking so I've given it a go.

Expect this code to be slower than your version due to the runtime varargs, but hopefully not by much.

Below is all you need to know about this branch:
- The assembly version is disabled since I don't have the skills to port my C over.
- The macros support 0 to 9 args, but this can be extended.
- I've only updated the `sample-c-appln` code.
- Format arguments are stored in the ring buffer directly preceeding the entry metadata. The metadata is now *24 bytes* and includes the argument count. The arguments list is padded to multiples of 24 to reduce the complexity of wrapping around the ring-buffer when we approach being full. (This limitation could be removed at the cost of more overflow checks.)
- The dump script starts decoding from the final entry and works backwards. This is because each entry is a variable length, and so the only entry who's position we truly know is the most recent one (discovered by reading the header's `idx % L3_MAX_SLOTS`). This is also why the metadata is written last.

I don't plan to update this more, but I hope you found this interesting and potentially useful.
